### PR TITLE
Fix two toolbars shown and toolbar's height in landscape mode in about screen

### DIFF
--- a/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/presentation/about/AboutFragment.kt
+++ b/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/presentation/about/AboutFragment.kt
@@ -1,6 +1,5 @@
 package ca.etsmtl.applets.etsmobile.presentation.about
 
-import android.content.res.Configuration
 import android.net.Uri
 import android.os.Bundle
 import android.transition.TransitionInflater
@@ -32,6 +31,7 @@ import kotlinx.android.synthetic.main.fragment_about.btnYoutube
 import kotlinx.android.synthetic.main.fragment_about.content
 import kotlinx.android.synthetic.main.fragment_about.ivAppletsLogo
 import kotlinx.android.synthetic.main.fragment_about.toolbarAbout
+import kotlin.math.max
 
 class AboutFragment : Fragment() {
 
@@ -60,15 +60,15 @@ class AboutFragment : Fragment() {
     }
 
     /**
-     * Sets margin to compensate for the status bar height when setting
+     * Sets top margin to compensate for the status bar height when setting
      * [WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS] to the window
      *
      * The flag allows the circular reveal animation to be integrated with the status bar.
      */
     private fun compensateForTranslucentBar() {
-        (content.layoutParams as? ViewGroup.MarginLayoutParams)?.apply {
-            topMargin = statusBarHeight
-        }
+        val layoutParams = content.layoutParams as? ViewGroup.MarginLayoutParams
+
+        layoutParams?.topMargin = statusBarHeight
     }
 
     private fun initViewTransition(savedInstanceState: Bundle?) {
@@ -105,7 +105,7 @@ class AboutFragment : Fragment() {
         val centerY = ivAppletsLogo.run {
             (y + statusBarHeight + toolbarAbout.height + height / 2).toInt()
         }
-        val endRadius = revealView.run { Math.max(revealView.width, revealView.height) }
+        val endRadius = revealView.run { max(revealView.width, revealView.height) }
         ViewAnimationUtils.createCircularReveal(
             revealView,
             centerX,
@@ -128,24 +128,27 @@ class AboutFragment : Fragment() {
 
     private fun setInitialActivityState() {
         (activity as? MainActivity)?.let {
-            it.appBarLayout.setExpanded(false, true)
             it.bottomNavigationView.setVisible(false)
             it.window.apply {
-                if (resources.configuration.orientation == Configuration.ORIENTATION_PORTRAIT) {
-                    setFlags(
-                        WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS,
-                        WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS
-                    )
-                }
+                setFlags(
+                    WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS,
+                    WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS
+                )
                 statusBarColor = it.getColorCompat(R.color.applets)
                 navigationBarColor = it.getColorCompat(R.color.applets)
             }
         }
     }
 
+    override fun onResume() {
+        super.onResume()
+
+        (activity as? MainActivity)?.appBarLayout?.setExpanded(false, false)
+    }
+
     private fun restoreActivityState() {
         (activity as? MainActivity)?.let {
-            it.appBarLayout.setExpanded(true, true)
+            it.appBarLayout.setExpanded(true, false)
             it.bottomNavigationView.setVisible(true)
             it.window.apply {
                 clearFlags(WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS)


### PR DESCRIPTION
- The `MainActivity`'s toolbar could show when the user rotated the screen. We now setExpanded to `false` in `onResume`.
- In landscape mode, the toolbar's height appeared to be too high because the `FLAG_LAYOUT_NO_LIMITS` flag was only applied in portrait mode.