### PR TITLE
Change schedule view

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -217,6 +217,10 @@ dependencies {
     // Buglife
     implementation "com.buglife.sdk:buglife-android:$versions.buglife"
 
+
+    // Android Week View
+    implementation "com.github.thellmund:Android-Week-View:3.4.2"
+
     implementation project(':android:repository')
 }
 

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -217,7 +217,6 @@ dependencies {
     // Buglife
     implementation "com.buglife.sdk:buglife-android:$versions.buglife"
 
-
     // Android Week View
     implementation "com.github.thellmund:Android-Week-View:3.4.2"
 

--- a/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/domain/FetchCurrentSessionUseCase.kt
+++ b/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/domain/FetchCurrentSessionUseCase.kt
@@ -4,12 +4,11 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.Transformations
 import ca.etsmtl.applets.etsmobile.R
 import ca.etsmtl.applets.etsmobile.presentation.App
-import model.Resource
 import ca.etsmtl.applets.repository.data.repository.signets.SessionRepository
-import ca.etsmtl.applets.repository.util.timeInSeconds
+import model.Resource
 import model.Session
 import model.SignetsUserCredentials
-import java.util.Date
+import utils.date.ETSMobileDate
 import javax.inject.Inject
 
 /**
@@ -25,7 +24,7 @@ class FetchCurrentSessionUseCase @Inject constructor(
         return Transformations.map(sessionRepository.getSessions(userCredentials) { true }) { res ->
             val sessions = res.data.orEmpty()
             val currentSession = sessions.find { session ->
-                Date().timeInSeconds in session.dateDebut..session.dateFin
+                ETSMobileDate() in session.dateDebut..session.dateFin
             } ?: sessions.getPreviousSession()
             ?: sessions.lastOrNull()
 
@@ -40,6 +39,6 @@ class FetchCurrentSessionUseCase @Inject constructor(
     }
 
     private fun List<Session>.getPreviousSession(): Session? = findLast { session ->
-        Date().timeInSeconds > session.dateFin
+        ETSMobileDate() > session.dateFin
     }
 }

--- a/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/presentation/schedule/ScheduleFragment.kt
+++ b/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/presentation/schedule/ScheduleFragment.kt
@@ -11,6 +11,7 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.ViewModelProviders
 import ca.etsmtl.applets.etsmobile.R
 import ca.etsmtl.applets.etsmobile.util.EventObserver
+import ca.etsmtl.applets.etsmobile.util.ProgressTimeLatch
 import com.alamkanak.weekview.MonthChangeListener
 import com.alamkanak.weekview.WeekView
 import com.alamkanak.weekview.WeekViewDisplayable
@@ -34,6 +35,9 @@ class ScheduleFragment : DaggerFragment() {
     @Inject
     lateinit var viewModelFactory: ViewModelProvider.Factory
     private lateinit var adapter: ScheduleAdapter
+    private val progressTimeLatch = ProgressTimeLatch(300, 900) {
+        progressBarSchedule?.isVisible = it
+    }
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -88,7 +92,7 @@ class ScheduleFragment : DaggerFragment() {
         })
 
         scheduleViewModel.loading.observe(this, Observer {
-            it?.let { progressBarSchedule.isVisible = it }
+            it?.let { progressTimeLatch.refreshing = it }
         })
 
         scheduleViewModel.errorMessage.observe(this, EventObserver {

--- a/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/presentation/schedule/ScheduleFragment.kt
+++ b/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/presentation/schedule/ScheduleFragment.kt
@@ -110,6 +110,7 @@ class ScheduleFragment : DaggerFragment() {
         scheduleViewModel.showEmptyView.observe(this, Observer {
             it?.let {
                 emptyViewSchedule.isVisible = it
+                weekView.isVisible = !it
             }
         })
 

--- a/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/presentation/schedule/ScheduleFragment.kt
+++ b/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/presentation/schedule/ScheduleFragment.kt
@@ -1,10 +1,12 @@
 package ca.etsmtl.applets.etsmobile.presentation.schedule
 
+import android.graphics.Color
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.Toast
+import androidx.core.graphics.ColorUtils
 import androidx.core.view.isVisible
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
@@ -17,11 +19,13 @@ import com.alamkanak.weekview.WeekView
 import com.alamkanak.weekview.WeekViewDisplayable
 import com.alamkanak.weekview.WeekViewEvent
 import dagger.android.support.DaggerFragment
-import kotlinx.android.synthetic.main.empty_view_schedule.*
-import kotlinx.android.synthetic.main.fragment_schedule.*
+import kotlinx.android.synthetic.main.empty_view_schedule.btnRetry
+import kotlinx.android.synthetic.main.empty_view_schedule.emptyViewSchedule
+import kotlinx.android.synthetic.main.fragment_schedule.progressBarSchedule
+import kotlinx.android.synthetic.main.fragment_schedule.weekView
 import model.Seance
 import utils.date.toCalendar
-import java.util.*
+import java.util.Calendar
 import javax.inject.Inject
 
 /**
@@ -51,13 +55,14 @@ class ScheduleFragment : DaggerFragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        setUpWeekView()
+        setupWeekView()
         btnRetry.setOnClickListener { scheduleViewModel.refresh() }
         subscribeUI()
     }
 
-    private fun setUpWeekView() {
+    private fun setupWeekView() {
         weekView.setShowTimeColumnHourSeparator(true)
+        // Listener called when the week view needs to load another month
         val monthChangeListener = object : MonthChangeListener<Seance> {
             override fun onMonthChange(startDate: Calendar, endDate: Calendar): List<WeekViewDisplayable<Seance>> {
                 return scheduleViewModel.getSeancesForDates(startDate, endDate).map { seance ->
@@ -72,14 +77,17 @@ class ScheduleFragment : DaggerFragment() {
     private fun Seance.toWeekViewEvent(): WeekViewEvent<Seance> {
         val style = WeekViewEvent.Style
             .Builder()
-            .setBackgroundColor(sigleCours.run {
-                this.hashCode()
-            })
+            .setBackgroundColor(ColorUtils.blendARGB(
+                sigleCours.hashCode(),
+                Color.BLACK,
+                0.3f
+            ))
             .build()
 
         return WeekViewEvent.Builder<Seance>()
-            .setTitle(libelleCours + "\n" + sigleCours)
-            .setLocation("\n" + local)
+            .setTitle("$libelleCours")
+            .setLocation("\n" +
+                "$sigleCours $nomActivite\n$local")
             .setStartTime(dateDebut.toCalendar())
             .setEndTime(dateFin.toCalendar())
             .setStyle(style)

--- a/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/presentation/schedule/ScheduleViewModel.kt
+++ b/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/presentation/schedule/ScheduleViewModel.kt
@@ -1,12 +1,6 @@
 package ca.etsmtl.applets.etsmobile.presentation.schedule
 
-import android.util.Range
-import androidx.annotation.VisibleForTesting
-import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.LifecycleObserver
-import androidx.lifecycle.LiveData
-import androidx.lifecycle.OnLifecycleEvent
-import androidx.lifecycle.ViewModel
+import androidx.lifecycle.*
 import ca.etsmtl.applets.etsmobile.R
 import ca.etsmtl.applets.etsmobile.domain.FetchFutureSeancesUseCase
 import ca.etsmtl.applets.etsmobile.extension.getGenericErrorMessage
@@ -14,10 +8,10 @@ import ca.etsmtl.applets.etsmobile.presentation.App
 import ca.etsmtl.applets.etsmobile.util.Event
 import ca.etsmtl.applets.etsmobile.util.RefreshableLiveData
 import com.shopify.livedataktx.map
-import com.shopify.livedataktx.nonNull
 import model.Resource
 import model.Seance
-import java.util.Calendar
+import utils.date.toCalendar
+import java.util.*
 import javax.inject.Inject
 
 /**
@@ -33,45 +27,35 @@ class ScheduleViewModel @Inject constructor(
         }
     }
 
-    val errorMessage: LiveData<Event<String?>> = seanceRes.nonNull().map {
+    val errorMessage: LiveData<Event<String?>> = Transformations.map(seanceRes) {
         if (app.getString(R.string.msg_api_no_seance) == it.message) {
             Event(null)
         } else
             it.getGenericErrorMessage(app)
     }
 
-    val seances: LiveData<Map<Range<Calendar>, List<Seance>>> = seanceRes.nonNull()
-        .map { res ->
-            res.data?.groupBy {
-                it.extractWeekRange()
-            }
-        }
+    val seances: LiveData<List<Seance>> = Transformations.map(seanceRes) { res ->
+        res.data
+    }
 
     val loading: LiveData<Boolean> = seanceRes.map {
         it == null || it.status == Resource.Status.LOADING
     }
 
-    val showEmptyView: LiveData<Boolean> = seanceRes.nonNull().map {
+    val showEmptyView: LiveData<Boolean> = Transformations.map(seanceRes) {
         it.status != Resource.Status.LOADING && (it?.data == null || it.data?.isEmpty() == true)
     }
 
-    /**
-     *  Finds the pair of calendar that represents the week that this seance belongs to
-     */
-    @VisibleForTesting
-    private fun Seance.extractWeekRange(): Range<Calendar> {
-        val beginningCal = Calendar.getInstance()
+    fun getSeancesForDates(startDate: Calendar, endDate: Calendar): List<Seance> {
+        val seances = seanceRes.value?.data
 
-        beginningCal.timeInMillis = dateDebut.timeInMilliseconds
-        beginningCal.set(Calendar.DAY_OF_WEEK, beginningCal.firstDayOfWeek)
-        beginningCal.set(Calendar.HOUR_OF_DAY, 0)
-        beginningCal.clear(Calendar.MINUTE)
-        beginningCal.clear(Calendar.SECOND)
-
-        val endCal = beginningCal.clone() as Calendar
-        endCal.add(Calendar.WEEK_OF_YEAR, 1)
-
-        return Range(beginningCal, endCal)
+        if (seances != null) {
+            return seances.filter { seance ->
+                seance.dateDebut.toCalendar() in startDate..endDate
+            }
+        } else {
+            return emptyList()
+        }
     }
 
     @OnLifecycleEvent(Lifecycle.Event.ON_CREATE)

--- a/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/presentation/schedule/ScheduleViewModel.kt
+++ b/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/presentation/schedule/ScheduleViewModel.kt
@@ -64,5 +64,7 @@ class ScheduleViewModel @Inject constructor(
     }
 
     @OnLifecycleEvent(Lifecycle.Event.ON_CREATE)
-    fun refresh() = seanceRes.refreshIfValueIsNull()
+    fun init() = seanceRes.refreshIfValueIsNull()
+
+    fun refresh() = seanceRes.refresh()
 }

--- a/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/presentation/schedule/ScheduleViewModel.kt
+++ b/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/presentation/schedule/ScheduleViewModel.kt
@@ -7,7 +7,7 @@ import androidx.lifecycle.OnLifecycleEvent
 import androidx.lifecycle.Transformations
 import androidx.lifecycle.ViewModel
 import ca.etsmtl.applets.etsmobile.R
-import ca.etsmtl.applets.etsmobile.domain.FetchFutureSeancesUseCase
+import ca.etsmtl.applets.etsmobile.domain.FetchCurrentAndFutureSeancesUseCase
 import ca.etsmtl.applets.etsmobile.extension.getGenericErrorMessage
 import ca.etsmtl.applets.etsmobile.presentation.App
 import ca.etsmtl.applets.etsmobile.util.Event
@@ -23,12 +23,12 @@ import javax.inject.Inject
  * Created by mykaelll87 on 2018-10-24
  */
 class ScheduleViewModel @Inject constructor(
-    private val fetchFutureSeancesUseCase: FetchFutureSeancesUseCase,
+    private val fetchCurrentAndFutureSeancesUseCase: FetchCurrentAndFutureSeancesUseCase,
     private val app: App
 ) : ViewModel(), LifecycleObserver {
     private var seanceRes = object : RefreshableLiveData<Resource<List<Seance>>>() {
         override fun updateSource(): LiveData<Resource<List<Seance>>> {
-            return fetchFutureSeancesUseCase()
+            return fetchCurrentAndFutureSeancesUseCase()
         }
     }
 

--- a/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/presentation/schedule/ScheduleViewModel.kt
+++ b/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/presentation/schedule/ScheduleViewModel.kt
@@ -1,6 +1,11 @@
 package ca.etsmtl.applets.etsmobile.presentation.schedule
 
-import androidx.lifecycle.*
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleObserver
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.OnLifecycleEvent
+import androidx.lifecycle.Transformations
+import androidx.lifecycle.ViewModel
 import ca.etsmtl.applets.etsmobile.R
 import ca.etsmtl.applets.etsmobile.domain.FetchFutureSeancesUseCase
 import ca.etsmtl.applets.etsmobile.extension.getGenericErrorMessage
@@ -11,7 +16,7 @@ import com.shopify.livedataktx.map
 import model.Resource
 import model.Seance
 import utils.date.toCalendar
-import java.util.*
+import java.util.Calendar
 import javax.inject.Inject
 
 /**
@@ -59,5 +64,5 @@ class ScheduleViewModel @Inject constructor(
     }
 
     @OnLifecycleEvent(Lifecycle.Event.ON_CREATE)
-    fun refresh() = seanceRes.refresh()
+    fun refresh() = seanceRes.refreshIfValueIsNull()
 }

--- a/android/app/src/main/res/layout/fragment_schedule.xml
+++ b/android/app/src/main/res/layout/fragment_schedule.xml
@@ -1,27 +1,52 @@
 <?xml version="1.0" encoding="utf-8"?>
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context="ca.etsmtl.applets.etsmobile.presentation.schedule.ScheduleFragment"
     android:layout_marginBottom="@dimen/design_bottom_navigation_height"
+    tools:context="ca.etsmtl.applets.etsmobile.presentation.schedule.ScheduleFragment"
     tools:ignore="PrivateResource">
 
-    <ca.etsmtl.applets.etsmobile.view.SwipeRefreshLayoutWithProgressTimeLatch
-        android:id="@+id/swipeRefreshLayoutSchedule"
+    <ProgressBar
+        android:id="@+id/progressBarSchedule"
+        style="?android:attr/progressBarStyleLarge"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:visibility="gone"
+        tools:visibility="visible" />
+
+    <include
+        layout="@layout/empty_view_schedule"
+        android:visibility="gone" />
+
+    <com.alamkanak.weekview.WeekView
+        android:id="@+id/weekView"
         android:layout_width="match_parent"
-        android:layout_height="match_parent">
-        <FrameLayout
-            android:layout_width="match_parent"
-            android:layout_height="match_parent">
-            <include
-                layout="@layout/empty_view_schedule"
-                android:visibility="gone" />
-            <androidx.viewpager.widget.ViewPager
-                android:id="@+id/schedule_pager"
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"/>
-        </FrameLayout>
-    </ca.etsmtl.applets.etsmobile.view.SwipeRefreshLayoutWithProgressTimeLatch>
+        android:layout_height="match_parent"
+        app:dayBackgroundColor="@android:color/transparent"
+        app:defaultEventColor="@color/colorPrimary"
+        app:eventTextColor="@android:color/white"
+        app:eventTextSize="14sp"
+        app:headerRowBackgroundColor="@android:color/transparent"
+        app:headerRowTextColor="@color/colorScheduleText"
+        app:hourHeight="40dp"
+        app:hourSeparatorColor="@color/etsGrisFonce"
+        app:nowLineColor="@color/colorPrimary"
+        app:numberOfVisibleDays="1"
+        app:overlappingEventGap="2dp"
+        app:showHourSeparator="false"
+        app:showNowLine="true"
+        app:showTimeColumnHourSeparator="false"
+        app:showTimeColumnSeparator="false"
+        app:singleDayHorizontalMargin="2dp"
+        app:timeColumnBackgroundColor="@android:color/transparent"
+        app:timeColumnPadding="8dp"
+        app:timeColumnSeparatorColor="@android:color/transparent"
+        app:timeColumnTextColor="@color/colorScheduleText"
+        app:todayBackgroundColor="@color/colorScheduleBg"
+        app:todayHeaderTextColor="@color/colorPrimary"
+        app:xScrollingSpeed="1" />
 </FrameLayout>
 

--- a/android/app/src/main/res/values-notnight/colors.xml
+++ b/android/app/src/main/res/values-notnight/colors.xml
@@ -8,4 +8,5 @@
     <color name="colorDialogBg">@android:color/white</color>
     <color name="colorControlNormal">@android:color/black</color>
     <color name="colorNavigationBar">@color/etsRougeClair</color>
+    <color name="colorScheduleText">@android:color/black</color>
 </resources>

--- a/android/app/src/main/res/values/colors.xml
+++ b/android/app/src/main/res/values/colors.xml
@@ -32,4 +32,6 @@
     <color name="colorDialogBg">@color/etsNoir</color>
     <color name="colorControlNormal">@color/etsGrisFonce</color>
     <color name="colorNavigationBar">@color/colorPrimaryDark</color>
+    <color name="colorScheduleBg">#2BEF3E45</color>
+    <color name="colorScheduleText">@android:color/white</color>
 </resources>

--- a/android/repository/src/main/kotlin/ca/etsmtl/applets/repository/data/db/entity/mapper/SignetsDbMapperExt.kt
+++ b/android/repository/src/main/kotlin/ca/etsmtl/applets/repository/data/db/entity/mapper/SignetsDbMapperExt.kt
@@ -22,6 +22,7 @@ import model.Seance
 import model.Session
 import model.SommaireElementsEvaluation
 import utils.date.ETSMobileDate
+import utils.date.MILLIS_PER_SECOND
 
 /**
  * Created by Sonphil on 09-07-18.
@@ -59,7 +60,7 @@ fun EvaluationEntity.toEvaluation() = Evaluation(
         this.session,
         this.nom,
         this.equipe,
-        dateCible?.let { ETSMobileDate(it * 1000) },
+        dateCible?.let { ETSMobileDate(it * MILLIS_PER_SECOND) },
         this.note,
         this.corrigeSur,
         this.notePourcentage,
@@ -78,8 +79,8 @@ fun List<EvaluationEntity>.toEvaluations() = map { it.toEvaluation() }
 
 fun EvaluationCoursEntity.toEvaluationCours() = EvaluationCours(
     session,
-    ETSMobileDate(dateDebutEvaluation * 1000),
-    ETSMobileDate(dateFinEvaluation * 1000),
+    ETSMobileDate(dateDebutEvaluation * MILLIS_PER_SECOND),
+    ETSMobileDate(dateFinEvaluation * MILLIS_PER_SECOND),
     enseignant,
     estComplete,
     groupe,
@@ -128,8 +129,8 @@ fun ProgrammeEntity.toProgramme() = Programme(
 fun List<ProgrammeEntity>.toProgrammes(): List<Programme> = map { it.toProgramme() }
 
 fun SeanceEntity.toSeance() = Seance(
-        ETSMobileDate(dateDebut * 1000),
-        ETSMobileDate(dateFin * 1000),
+        ETSMobileDate(dateDebut * MILLIS_PER_SECOND),
+        ETSMobileDate(dateFin * MILLIS_PER_SECOND),
         this.nomActivite,
         this.local,
         this.descriptionActivite,
@@ -159,8 +160,8 @@ fun SommaireElementsEvaluationEntity.toSommaireEvaluation() = SommaireElementsEv
 fun SessionEntity.toSession() = Session(
         abrege,
         auLong,
-        dateDebut,
-        dateFin,
+        ETSMobileDate(dateDebut * MILLIS_PER_SECOND),
+        ETSMobileDate(dateFin * MILLIS_PER_SECOND),
         dateFinCours,
         dateDebutChemiNot,
         dateFinChemiNot,

--- a/android/repository/src/main/kotlin/ca/etsmtl/applets/repository/data/repository/signets/LoginRepository.kt
+++ b/android/repository/src/main/kotlin/ca/etsmtl/applets/repository/data/repository/signets/LoginRepository.kt
@@ -20,6 +20,7 @@ import javax.inject.Inject
 
 class LoginRepository @Inject constructor(
     private val securePrefs: SecurePreferences,
+    private val prefs: SharedPreferences,
     private val appExecutors: AppExecutors,
     private val db: AppDatabase,
     private val dashboardCardDatabase: DashboardCardDatabase
@@ -144,6 +145,8 @@ class LoginRepository @Inject constructor(
     suspend fun clearUserData() {
         withContext(EtsMobileDispatchers.IO) {
             securePrefs.clear()
+
+            prefs.edit().clear().apply()
 
             SignetsUserCredentials.INSTANCE = null
 

--- a/android/repository/src/main/kotlin/ca/etsmtl/applets/repository/data/repository/signets/SeanceRepository.kt
+++ b/android/repository/src/main/kotlin/ca/etsmtl/applets/repository/data/repository/signets/SeanceRepository.kt
@@ -11,12 +11,12 @@ import ca.etsmtl.applets.repository.data.api.response.signets.ApiListeDesSeances
 import ca.etsmtl.applets.repository.data.api.response.signets.ApiSignetsModel
 import ca.etsmtl.applets.repository.data.db.dao.signets.SeanceDao
 import ca.etsmtl.applets.repository.data.db.entity.mapper.toSeances
-import ca.etsmtl.applets.repository.util.unixToDefaultSignetsDate
 import model.Cours
 import model.Resource
 import model.Seance
 import model.Session
 import model.SignetsUserCredentials
+import utils.date.toDefaultSignetsDate
 import javax.inject.Inject
 
 /**
@@ -79,8 +79,8 @@ class SeanceRepository @Inject constructor(
                                 userCredentials.motPasse,
                                 cours?.sigle ?: "",
                                 session.abrege,
-                            session.dateDebut.unixToDefaultSignetsDate(),
-                            session.dateFin.unixToDefaultSignetsDate()
+                            session.dateDebut.toDefaultSignetsDate(),
+                            session.dateFin.toDefaultSignetsDate()
                         )
                 )
             }

--- a/android/repository/src/main/kotlin/ca/etsmtl/applets/repository/data/repository/signets/SeanceRepository.kt
+++ b/android/repository/src/main/kotlin/ca/etsmtl/applets/repository/data/repository/signets/SeanceRepository.kt
@@ -16,6 +16,7 @@ import model.Resource
 import model.Seance
 import model.Session
 import model.SignetsUserCredentials
+import utils.date.plus
 import utils.date.toDefaultSignetsDate
 import javax.inject.Inject
 
@@ -28,6 +29,10 @@ class SeanceRepository @Inject constructor(
     private val api: SignetsApi,
     private val dao: SeanceDao
 ) : SignetsRepository(appExecutors) {
+    companion object {
+        const val NB_MS_IN_A_DAY = 86400000L
+    }
+
     /**
      * Returns the schedule of the sessions for a given course and a given session
      *
@@ -80,7 +85,7 @@ class SeanceRepository @Inject constructor(
                                 cours?.sigle ?: "",
                                 session.abrege,
                             session.dateDebut.toDefaultSignetsDate(),
-                            session.dateFin.toDefaultSignetsDate()
+                            (session.dateFin + NB_MS_IN_A_DAY).toDefaultSignetsDate()
                         )
                 )
             }

--- a/build.gradle
+++ b/build.gradle
@@ -57,5 +57,6 @@ allprojects {
         jcenter()
         maven { url 'https://dl.bintray.com/kotlin/kotlin-eap' }
         maven { url "https://kotlin.bintray.com/kotlinx" }
+        maven { url 'https://jitpack.io' }
     }
 }

--- a/shared/src/androidMain/kotlin/utils/date/ETSMobileDate.kt
+++ b/shared/src/androidMain/kotlin/utils/date/ETSMobileDate.kt
@@ -64,3 +64,13 @@ private fun Calendar.toETSMobileDate(timestamp: Long? = null): ETSMobileDate {
 }
 
 fun ETSMobileDate.toJvmDate(): Date = Date(timeInMilliseconds)
+
+fun ETSMobileDate.toCalendar(): Calendar = Calendar.getInstance().apply {
+    set(Calendar.YEAR, year)
+    set(Calendar.MONTH, month.ordinal)
+    set(Calendar.DAY_OF_MONTH, dayOfMonth)
+    set(Calendar.HOUR_OF_DAY, hours)
+    set(Calendar.MINUTE, minutes)
+    set(Calendar.SECOND, seconds)
+    set(Calendar.MILLISECOND, 0)
+}

--- a/shared/src/androidMain/kotlin/utils/date/ETSMobileDate.kt
+++ b/shared/src/androidMain/kotlin/utils/date/ETSMobileDate.kt
@@ -67,6 +67,7 @@ fun ETSMobileDate.toJvmDate(): Date = Date(timeInMilliseconds)
 
 fun ETSMobileDate.toCalendar(): Calendar = Calendar.getInstance().apply {
     set(Calendar.YEAR, year)
+    // January is month 0 in Java's Calendar
     set(Calendar.MONTH, month.ordinal)
     set(Calendar.DAY_OF_MONTH, dayOfMonth)
     set(Calendar.HOUR_OF_DAY, hours)

--- a/shared/src/commonMain/kotlin/model/Session.kt
+++ b/shared/src/commonMain/kotlin/model/Session.kt
@@ -1,10 +1,12 @@
 package model
 
+import utils.date.ETSMobileDate
+
 data class Session(
     var abrege: String,
     var auLong: String,
-    var dateDebut: Long,
-    var dateFin: Long,
+    var dateDebut: ETSMobileDate,
+    var dateFin: ETSMobileDate,
     var dateFinCours: Long,
     var dateDebutChemiNot: Long,
     var dateFinChemiNot: Long,

--- a/shared/src/commonMain/kotlin/utils/date/ETSMobileDate.kt
+++ b/shared/src/commonMain/kotlin/utils/date/ETSMobileDate.kt
@@ -55,6 +55,22 @@ data class ETSMobileDate internal constructor(
 }
 
 /**
+ * Formats date to Signets default date format (yyyy-MM-dd)
+ */
+fun ETSMobileDate.toDefaultSignetsDate(): String {
+    val monthStr = (month.ordinal + 1).twoDigits()
+    val dayOfMonthStr = dayOfMonth.twoDigits()
+
+    return "$year-$monthStr-$dayOfMonthStr"
+}
+
+private fun Int.twoDigits(): String {
+    val str = "$this"
+
+    return if (str.length < 2) { "0$str" } else str
+}
+
+/**
  * Creates a new [ETSMobileDate] from the specified [timestamp]
  *
  * @param timestamp Unix time (Number of Epoch milliseconds) (it is `now` by default)


### PR DESCRIPTION
Currently, the schedule only display courses. In the future, more types of events may be added, so the view has been be changed to allow more events to be displayed.

- Use thellmund's [fork](https://github.com/thellmund/Android-Week-View) of Android-Week-View to display the `Seance`s
- Replace `SwipeRefreshLayout` with a simple `ProgressBar` because it doesn't integrate well with the library. The main issue is that `SwipeRefreshLayout` prevent the user from scrolling the `WeekView` up.
- When requesting the `Seance`s, add one more day to the session's end date to include the last day of the session. (Fix #93)
