### PR TITLE
Allow user to access the app right away if he has successfully login before

### DIFF
--- a/shared/src/commonMain/kotlin/domain/LoginWithSavedCredentialsUseCase.kt
+++ b/shared/src/commonMain/kotlin/domain/LoginWithSavedCredentialsUseCase.kt
@@ -2,7 +2,6 @@ package domain
 
 import di.Inject
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.withContext
 import model.Resource
@@ -13,23 +12,19 @@ import kotlin.coroutines.coroutineContext
  */
 
 class LoginWithSavedCredentialsUseCase @Inject constructor(
-    private val fetchSavedUserCredentialsUseCase: FetchSavedUserCredentialsUseCase,
-    private val checkUserCredentialsAreValidUseCase: CheckUserCredentialsAreValidUseCase
+    private val fetchSavedUserCredentialsUseCase: FetchSavedUserCredentialsUseCase
 ) {
     suspend operator fun invoke(): Flow<Resource<Boolean>> {
         return withContext(coroutineContext) {
             flow<Resource<Boolean>> {
-                emit(Resource.loading<Boolean>(null))
+                emit(Resource.loading(null))
 
                 val credentials = fetchSavedUserCredentialsUseCase()
 
                 if (credentials == null) {
                     emit(Resource.error("", false))
                 } else {
-                    emitAll(checkUserCredentialsAreValidUseCase(
-                        credentials.universalCode,
-                        credentials.password
-                    ))
+                    emit(Resource.success(true))
                 }
             }
         }


### PR DESCRIPTION
Before, `FetchSavedUserCredentialsUseCase` would submit the saved credentials to the API to check if they were valid. This prevented the user from accessing the app if the device was offline. Furthermore, the app's startup would be slowed down. Even though the request didn't take a while to finish, it was still noticeable.