### PR TITLE
Add `ProgressTimeLatch` to each `ProgressBar` to prevent it from "flashing"

### DIFF
--- a/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/presentation/schedule/ScheduleFragment.kt
+++ b/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/presentation/schedule/ScheduleFragment.kt
@@ -17,7 +17,6 @@ import androidx.lifecycle.ViewModelProviders
 import androidx.navigation.fragment.findNavController
 import ca.etsmtl.applets.etsmobile.R
 import ca.etsmtl.applets.etsmobile.util.EventObserver
-import ca.etsmtl.applets.etsmobile.util.ProgressTimeLatch
 import com.alamkanak.weekview.MonthChangeListener
 import com.alamkanak.weekview.ScrollListener
 import com.alamkanak.weekview.WeekView
@@ -45,9 +44,6 @@ class ScheduleFragment : DaggerFragment() {
     @Inject
     lateinit var viewModelFactory: ViewModelProvider.Factory
     private lateinit var adapter: ScheduleAdapter
-    private val progressTimeLatch = ProgressTimeLatch(300, 900) {
-        progressBarSchedule?.isVisible = it
-    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         setHasOptionsMenu(true)
@@ -135,7 +131,7 @@ class ScheduleFragment : DaggerFragment() {
         })
 
         scheduleViewModel.loading.observe(this, Observer {
-            it?.let { progressTimeLatch.refreshing = it }
+            it?.let { progressBarSchedule.isVisible = it }
         })
 
         scheduleViewModel.errorMessage.observe(this, EventObserver {

--- a/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/view/ProgressBarWithProgressTimeLatch.kt
+++ b/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/view/ProgressBarWithProgressTimeLatch.kt
@@ -1,0 +1,32 @@
+package ca.etsmtl.applets.etsmobile.view
+
+import android.content.Context
+import android.util.AttributeSet
+import android.view.View
+import android.widget.ProgressBar
+import ca.etsmtl.applets.etsmobile.util.ProgressTimeLatch
+
+/**
+ * A [ProgressBar] combined with a [ProgressTimeLatch] to prevent it from "flashing". The
+ * [ProgressTimeLatch] waits a minimum of time before showing the [ProgressBar] and, once, visible,
+ * the [ProgressBar] will be visible for a minimum of time.
+ *
+ * Created by Sonphil on 09-08-19.
+ */
+
+class ProgressBarWithProgressTimeLatch @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null
+) : ProgressBar(context, attrs) {
+    private val progressLatch: ProgressTimeLatch by lazy {
+        ProgressTimeLatch(300, 1500) { visible ->
+            val visibility = if (visible) View.VISIBLE else View.GONE
+
+            super.setVisibility(visibility)
+        }
+    }
+
+    override fun setVisibility(visibility: Int) {
+        progressLatch.refreshing = visibility == View.VISIBLE
+    }
+}

--- a/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/view/SwipeRefreshLayoutWithProgressTimeLatch.kt
+++ b/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/view/SwipeRefreshLayoutWithProgressTimeLatch.kt
@@ -6,6 +6,10 @@ import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
 import ca.etsmtl.applets.etsmobile.util.ProgressTimeLatch
 
 /**
+ * A [SwipeRefreshLayout] combined with a [ProgressTimeLatch] to prevent it from "flashing". The
+ * [ProgressTimeLatch] waits a minimum of time before showing the [SwipeRefreshLayout] and, once,
+ * visible, the [SwipeRefreshLayout] will be visible for a minimum of time.
+ *
  * Created by Sonphil on 30-03-19.
  */
 

--- a/android/app/src/main/res/layout/fragment_schedule.xml
+++ b/android/app/src/main/res/layout/fragment_schedule.xml
@@ -53,7 +53,7 @@
         app:todayHeaderTextColor="@color/colorPrimary"
         app:xScrollingSpeed="1" />
 
-    <ProgressBar
+    <ca.etsmtl.applets.etsmobile.view.ProgressBarWithProgressTimeLatch
         android:id="@+id/progressBarSchedule"
         style="?android:attr/progressBarStyleLarge"
         android:layout_width="wrap_content"

--- a/android/app/src/main/res/layout/fragment_splash.xml
+++ b/android/app/src/main/res/layout/fragment_splash.xml
@@ -6,7 +6,7 @@
     android:theme="@style/LoginTheme"
     tools:context="ca.etsmtl.applets.etsmobile.presentation.splash.SplashFragment">
 
-    <ProgressBar
+    <ca.etsmtl.applets.etsmobile.view.ProgressBarWithProgressTimeLatch
         android:id="@+id/progressBarSplash"
         style="?android:attr/progressBarStyleLarge"
         android:layout_width="wrap_content"


### PR DESCRIPTION
New class: `ProgressBarWithProgressTimeLatch`

The `ProgressTimeLatch` waits a minimum of time before showing the `ProgressBar` and, once, visible, the `ProgressBar` will be visible for a minimum of time.