### PR TITLE
Fix AWS library crash when device was offline

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -221,7 +221,7 @@ dependencies {
     implementation "com.github.thellmund:Android-Week-View:3.4.2"
 
     // ETSMobile-Notifications
-    implementation 'ca.applets.etsmobilenotifications:etsmobilenotifications:1.0.0'
+    implementation "ca.applets.etsmobilenotifications:etsmobilenotifications:1.0.2"
 
     implementation project(':android:repository')
 }

--- a/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/extension/ContextExt.kt
+++ b/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/extension/ContextExt.kt
@@ -9,6 +9,8 @@ import androidx.annotation.ColorInt
 import androidx.annotation.ColorRes
 import androidx.annotation.RequiresPermission
 import androidx.core.content.ContextCompat
+import ca.etsmtl.applets.etsmobilenotifications.NotificationsLoginManager
+import model.UserCredentials
 
 /**
  * Created by Sonphil on 18-05-18.
@@ -47,4 +49,15 @@ fun Context.getColorFromAttr(
 ): Int {
     theme.resolveAttribute(attrColor, typedValue, resolveRefs)
     return typedValue.data
+}
+
+/**
+ * Provides credentials to notifications library and lets it register the user to AWS SNS
+ */
+fun Context.loginNotifications() {
+    UserCredentials.INSTANCE?.let { creds ->
+        if (isDeviceConnected()) {
+            NotificationsLoginManager.login(this, creds.universalCode.value, creds.domain)
+        }
+    }
 }

--- a/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/presentation/login/LoginFragment.kt
+++ b/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/presentation/login/LoginFragment.kt
@@ -17,11 +17,11 @@ import ca.etsmtl.applets.etsmobile.R
 import ca.etsmtl.applets.etsmobile.extension.fadeTo
 import ca.etsmtl.applets.etsmobile.extension.getColorCompat
 import ca.etsmtl.applets.etsmobile.extension.hideKeyboard
+import ca.etsmtl.applets.etsmobile.extension.loginNotifications
 import ca.etsmtl.applets.etsmobile.extension.open
 import ca.etsmtl.applets.etsmobile.extension.setVisible
 import ca.etsmtl.applets.etsmobile.extension.toLiveData
 import ca.etsmtl.applets.etsmobile.presentation.main.MainActivity
-import ca.etsmtl.applets.etsmobilenotifications.NotificationsLoginManager
 import com.bumptech.glide.Glide
 import com.google.android.material.textfield.TextInputLayout
 import dagger.android.support.DaggerFragment
@@ -37,7 +37,6 @@ import kotlinx.android.synthetic.main.include_login_form.layoutPassword
 import kotlinx.android.synthetic.main.include_login_form.layoutUniversalCode
 import kotlinx.android.synthetic.main.include_login_form.password
 import kotlinx.android.synthetic.main.include_login_form.universalCode
-import model.UserCredentials
 import presentation.login.LoginViewModel
 import javax.inject.Inject
 
@@ -159,13 +158,7 @@ class LoginFragment : DaggerFragment() {
             })
 
             navigateToDashboard.toLiveData().observe(this@LoginFragment, Observer {
-                UserCredentials.INSTANCE?.let {
-                    NotificationsLoginManager.login(
-                        requireContext(),
-                        it.universalCode.value,
-                        it.domain
-                    )
-                }
+                requireContext().loginNotifications()
 
                 findNavController().navigate(LoginFragmentDirections.actionFragmentLoginToFragmentDashboard())
             })

--- a/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/presentation/splash/SplashFragment.kt
+++ b/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/presentation/splash/SplashFragment.kt
@@ -11,12 +11,11 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.ViewModelProviders
 import androidx.navigation.fragment.findNavController
 import ca.etsmtl.applets.etsmobile.R
+import ca.etsmtl.applets.etsmobile.extension.loginNotifications
 import ca.etsmtl.applets.etsmobile.extension.toLiveData
 import ca.etsmtl.applets.etsmobile.extension.toast
-import ca.etsmtl.applets.etsmobilenotifications.NotificationsLoginManager
 import dagger.android.support.DaggerFragment
 import kotlinx.android.synthetic.main.fragment_splash.progressBarSplash
-import model.UserCredentials
 import presentation.SplashViewModel
 import javax.inject.Inject
 
@@ -60,13 +59,7 @@ class SplashFragment : DaggerFragment() {
             })
 
             navigateToDashboard.toLiveData().observe(this@SplashFragment, Observer {
-                UserCredentials.INSTANCE?.let {
-                    NotificationsLoginManager.login(
-                        requireContext(),
-                        it.universalCode.value,
-                        it.domain
-                    )
-                }
+                requireContext().loginNotifications()
 
                 findNavController().navigate(SplashFragmentDirections.actionFragmentSplashToFragmentDashboard())
             })

--- a/android/app/src/main/res/layout/include_login_form.xml
+++ b/android/app/src/main/res/layout/include_login_form.xml
@@ -16,6 +16,7 @@
         app:endIconMode="custom"
         app:endIconTint="@android:color/white"
         app:errorEnabled="true"
+        app:errorIconDrawable="@null"
         app:errorTextColor="@color/material_yellow_500"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent">

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ buildscript {
             "leakcanary": "2.0-alpha-1",
             "lifecycle": "2.0.0",
             "lifecycle_viewmodel_ktx": "2.2.0-alpha02",
-            "material_components": "1.1.0-alpha08",
+            "material_components": "1.1.0-alpha09",
             "materialprogressview": "1.0.6",
             "mockito": "2.28.2",
             "mockito_kotlin": "2.1.0",


### PR DESCRIPTION
- Bump Material Components library to 1.1.0-alpha09
- Bump notification library to 1.0.2
- Add `loginNotifications` extension function that checks if the device is connected before calling `NotificationsLoginManager.login`
`AmazonHttpClient` wasn't able to connect and caused the app to crash