### PR TITLE
Generate a color for each separator in the schedule card

### DIFF
--- a/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/extension/SeanceExt.kt
+++ b/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/extension/SeanceExt.kt
@@ -1,0 +1,15 @@
+package ca.etsmtl.applets.etsmobile.extension
+
+import android.graphics.Color
+import androidx.core.graphics.ColorUtils
+import model.Seance
+
+/**
+ * Created by Sonphil on 13-08-19.
+ */
+
+fun Seance.generateColor() = ColorUtils.blendARGB(
+    sigleCours.hashCode(),
+    Color.BLACK,
+    0.3f
+)

--- a/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/presentation/schedule/ScheduleFragment.kt
+++ b/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/presentation/schedule/ScheduleFragment.kt
@@ -1,6 +1,5 @@
 package ca.etsmtl.applets.etsmobile.presentation.schedule
 
-import android.graphics.Color
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.Menu
@@ -9,13 +8,13 @@ import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
 import android.widget.Toast
-import androidx.core.graphics.ColorUtils
 import androidx.core.view.isVisible
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.ViewModelProviders
 import androidx.navigation.fragment.findNavController
 import ca.etsmtl.applets.etsmobile.R
+import ca.etsmtl.applets.etsmobile.extension.generateColor
 import ca.etsmtl.applets.etsmobile.util.EventObserver
 import com.alamkanak.weekview.MonthChangeListener
 import com.alamkanak.weekview.ScrollListener
@@ -106,11 +105,7 @@ class ScheduleFragment : DaggerFragment() {
     private fun Seance.toWeekViewEvent(): WeekViewEvent<Seance> {
         val style = WeekViewEvent.Style
             .Builder()
-            .setBackgroundColor(ColorUtils.blendARGB(
-                sigleCours.hashCode(),
-                Color.BLACK,
-                0.3f
-            ))
+            .setBackgroundColor(generateColor())
             .build()
 
         return WeekViewEvent.Builder<Seance>()

--- a/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/presentation/schedule/week/ScheduleWeekInnerListAdapter.kt
+++ b/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/presentation/schedule/week/ScheduleWeekInnerListAdapter.kt
@@ -7,7 +7,9 @@ import android.view.ViewGroup
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.RecyclerView
 import ca.etsmtl.applets.etsmobile.R
+import ca.etsmtl.applets.etsmobile.extension.generateColor
 import kotlinx.android.extensions.LayoutContainer
+import kotlinx.android.synthetic.main.sub_item_schedule.separatorSchedule
 import kotlinx.android.synthetic.main.sub_item_schedule.textViewScheduleEndTime
 import kotlinx.android.synthetic.main.sub_item_schedule.textViewScheduleLocal
 import kotlinx.android.synthetic.main.sub_item_schedule.textViewScheduleSigleGroup
@@ -64,6 +66,7 @@ class ScheduleWeekInnerListAdapter : RecyclerView.Adapter<ScheduleWeekInnerListA
                     dateFin.timeInMilliseconds,
                     DateUtils.FORMAT_SHOW_TIME
                 )
+            holder.separatorSchedule.setBackgroundColor(generateColor())
         }
     }
 

--- a/android/app/src/main/res/layout/sub_item_schedule.xml
+++ b/android/app/src/main/res/layout/sub_item_schedule.xml
@@ -8,9 +8,8 @@
 
     <TextView
         android:id="@+id/textViewScheduleStartTime"
-        android:layout_width="85dp"
+        android:layout_width="68dp"
         android:layout_height="wrap_content"
-        android:layout_marginStart="8dp"
         android:textAlignment="textEnd"
         android:textColor="@color/colorPrimary"
         android:textSize="@dimen/material_component_lists_single_line_text_size"
@@ -20,9 +19,8 @@
 
     <TextView
         android:id="@+id/textViewScheduleEndTime"
-        android:layout_width="85dp"
+        android:layout_width="68dp"
         android:layout_height="wrap_content"
-        android:layout_marginStart="8dp"
         android:textAlignment="textEnd"
         android:textColor="@color/colorPrimary"
         android:textSize="@dimen/material_component_lists_single_line_text_size"
@@ -32,16 +30,14 @@
         tools:text="12:00" />
 
     <View
-        android:id="@+id/view"
-        android:layout_width="1dp"
+        android:id="@+id/separatorSchedule"
+        android:layout_width="3dp"
         android:layout_height="0dp"
         android:layout_marginStart="8dp"
-        android:layout_marginTop="8dp"
-        android:layout_marginBottom="8dp"
         android:background="@color/browser_actions_divider_color"
         app:layout_constraintBottom_toBottomOf="@+id/textViewScheduleType"
         app:layout_constraintEnd_toStartOf="@+id/textViewScheduleTitreCours"
-        app:layout_constraintStart_toEndOf="@+id/textViewScheduleStartTime"
+        app:layout_constraintStart_toEndOf="@+id/textViewScheduleEndTime"
         app:layout_constraintTop_toTopOf="@+id/textViewScheduleTitreCours" />
 
     <TextView
@@ -51,13 +47,12 @@
         android:layout_marginStart="8dp"
         android:layout_marginTop="8dp"
         android:layout_marginEnd="8dp"
-        android:textAlignment="viewStart"
         android:textColor="@color/colorPrimary"
         android:textSize="@dimen/material_component_lists_single_line_text_size"
         android:textStyle="bold"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintHorizontal_bias="0.5"
-        app:layout_constraintStart_toEndOf="@+id/view"
+        app:layout_constraintStart_toEndOf="@+id/separatorSchedule"
         app:layout_constraintTop_toTopOf="parent"
         tools:text="Nom Cours" />
 


### PR DESCRIPTION
The color is generated by using the `generateColor` extension function which use the hashcode of the `Seance`'s sigle.

![image](https://user-images.githubusercontent.com/22182973/62944871-9813c300-bdab-11e9-9e72-5220962203b8.png)
