### PR TITLE
Fix crash occuring on logout when the device is offline

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -221,7 +221,7 @@ dependencies {
     implementation "com.github.thellmund:Android-Week-View:3.4.2"
 
     // ETSMobile-Notifications
-    implementation "ca.applets.etsmobilenotifications:etsmobilenotifications:1.0.2"
+    implementation "ca.applets.etsmobilenotifications:etsmobilenotifications:1.1.0"
 
     implementation project(':android:repository')
 }

--- a/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/extension/ContextExt.kt
+++ b/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/extension/ContextExt.kt
@@ -56,8 +56,6 @@ fun Context.getColorFromAttr(
  */
 fun Context.loginNotifications() {
     UserCredentials.INSTANCE?.let { creds ->
-        if (isDeviceConnected()) {
-            NotificationsLoginManager.login(this, creds.universalCode.value, creds.domain)
-        }
+        NotificationsLoginManager.login(this, creds.universalCode.value, creds.domain)
     }
 }


### PR DESCRIPTION
Bump notification liibrary to 1.1.0 which has the following change: https://github.com/ApplETS/ETSMobile-Notifications-Android/pull/13
The version 1.1.0 of the library uses [WorkManager](https://developer.android.com/topic/libraries/architecture/workmanager) to create/delete the user's endpoint on SNS when the device is connected.