### PR TITLE
Fix seance color can be too dark when dark mode is enabled

### DIFF
--- a/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/extension/ContextExt.kt
+++ b/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/extension/ContextExt.kt
@@ -2,6 +2,7 @@ package ca.etsmtl.applets.etsmobile.extension
 
 import android.Manifest
 import android.content.Context
+import android.content.res.Configuration
 import android.net.ConnectivityManager
 import android.util.TypedValue
 import androidx.annotation.AttrRes
@@ -15,6 +16,16 @@ import model.UserCredentials
 /**
  * Created by Sonphil on 18-05-18.
  */
+
+/**
+ * Returns true when dark theme is on, false otherwise.
+ */
+inline val Context.isDarkMode: Boolean
+    get() {
+        val uiMode = resources.configuration.uiMode
+
+        return uiMode and Configuration.UI_MODE_NIGHT_MASK == Configuration.UI_MODE_NIGHT_YES
+    }
 
 /**
  * Check if the device is connected

--- a/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/extension/SeanceExt.kt
+++ b/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/extension/SeanceExt.kt
@@ -1,5 +1,6 @@
 package ca.etsmtl.applets.etsmobile.extension
 
+import android.content.Context
 import android.graphics.Color
 import androidx.core.graphics.ColorUtils
 import model.Seance
@@ -8,8 +9,16 @@ import model.Seance
  * Created by Sonphil on 13-08-19.
  */
 
-fun Seance.generateColor() = ColorUtils.blendARGB(
-    sigleCours.hashCode(),
-    Color.BLACK,
-    0.3f
-)
+fun Seance.generateColor(context: Context): Int {
+    val secondColor = if (context.isDarkMode) {
+        Color.WHITE
+    } else {
+        Color.BLACK
+    }
+
+    return ColorUtils.blendARGB(
+        sigleCours.hashCode(),
+        secondColor,
+        0.3f
+    )
+}

--- a/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/presentation/dashboard/DashboardFragment.kt
+++ b/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/presentation/dashboard/DashboardFragment.kt
@@ -121,4 +121,10 @@ class DashboardFragment : DaggerFragment() {
 
         super.onPause()
     }
+
+    override fun onDestroyView() {
+        rvCards.adapter = null
+
+        super.onDestroyView()
+    }
 }

--- a/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/presentation/gradesdetails/GradesDetailsActivity.kt
+++ b/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/presentation/gradesdetails/GradesDetailsActivity.kt
@@ -6,12 +6,12 @@ import android.transition.TransitionInflater
 import android.view.MenuItem
 import android.view.View
 import androidx.appcompat.app.AppCompatActivity
-import androidx.appcompat.app.AppCompatDelegate
 import androidx.core.app.ActivityOptionsCompat
 import androidx.core.util.Pair
 import androidx.core.view.isVisible
 import ca.etsmtl.applets.etsmobile.R
 import ca.etsmtl.applets.etsmobile.extension.getColorCompat
+import ca.etsmtl.applets.etsmobile.extension.isDarkMode
 import ca.etsmtl.applets.etsmobile.extension.toast
 import ca.etsmtl.applets.etsmobile.presentation.BaseActivity
 import kotlinx.android.synthetic.main.activity_grades_details.*
@@ -71,7 +71,7 @@ class GradesDetailsActivity : BaseActivity() {
 
         setupToolbar()
 
-        if (AppCompatDelegate.getDefaultNightMode() == AppCompatDelegate.MODE_NIGHT_YES) {
+        if (isDarkMode) {
             window.statusBarColor = getColorCompat(R.color.etsRougeClair)
         }
 
@@ -133,7 +133,7 @@ class GradesDetailsActivity : BaseActivity() {
             }
         }
 
-        if (AppCompatDelegate.getDefaultNightMode() == AppCompatDelegate.MODE_NIGHT_YES) {
+        if (isDarkMode) {
             window.statusBarColor = getColorCompat(R.color.colorPrimaryDark)
         }
 

--- a/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/presentation/schedule/ScheduleFragment.kt
+++ b/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/presentation/schedule/ScheduleFragment.kt
@@ -105,7 +105,7 @@ class ScheduleFragment : DaggerFragment() {
     private fun Seance.toWeekViewEvent(): WeekViewEvent<Seance> {
         val style = WeekViewEvent.Style
             .Builder()
-            .setBackgroundColor(generateColor())
+            .setBackgroundColor(generateColor(requireContext()))
             .build()
 
         return WeekViewEvent.Builder<Seance>()

--- a/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/presentation/schedule/week/ScheduleWeekInnerListAdapter.kt
+++ b/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/presentation/schedule/week/ScheduleWeekInnerListAdapter.kt
@@ -66,7 +66,7 @@ class ScheduleWeekInnerListAdapter : RecyclerView.Adapter<ScheduleWeekInnerListA
                     dateFin.timeInMilliseconds,
                     DateUtils.FORMAT_SHOW_TIME
                 )
-            holder.separatorSchedule.setBackgroundColor(generateColor())
+            holder.separatorSchedule.setBackgroundColor(generateColor(holder.itemView.context))
         }
     }
 

--- a/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/presentation/settings/SettingsFragment.kt
+++ b/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/presentation/settings/SettingsFragment.kt
@@ -51,8 +51,6 @@ class SettingsFragment : PreferenceFragmentCompat(), Preference.OnPreferenceChan
     private fun handleDarkThemePreferenceChange(newValue: Any?) {
         if (newValue is String) {
             context?.applyDarkThemePref(newValue)
-
-            activity?.recreate()
         }
     }
 


### PR DESCRIPTION
Make the color lean toward white when dark theme is on and toward black when it's off

Should fix the following issue:
![image](https://user-images.githubusercontent.com/22182973/63123879-ff7e6e00-bf77-11e9-85aa-8b8ee5bd1338.png)
