### PR TITLE
Update Gradle version and disable automatic build ID generation in debug build

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -46,6 +46,8 @@ android {
             minifyEnabled false
             signingConfig signingConfigs.debug
             manifestPlaceholders = [enableCrashReporting: "false"]
+            // Prevent Crashlytics from updating app resources with its own unique build ID
+            ext.alwaysUpdateBuildId = false
         }
 
         release {

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ buildscript {
             "flexbox" : "1.1.0",
             "glide": "4.9.0",
             "google_maps": "17.0.0",
-            "gradle": '3.4.2',
+            "gradle": '3.5.0',
             "groupie": "2.3.0",
             "junit": "4.12",
             "kotlin": "1.3.41",

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Jan 14 14:09:46 EST 2019
+#Thu Aug 22 13:16:21 EDT 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip


### PR DESCRIPTION
Disable automatic build ID generation to prevent Crashlytics from updating app resources with its own unique build ID.
This side effect of Crashlytics was forcing Apply Changes from restarting each time: https://www.reddit.com/r/androiddev/comments/ct29vl/whats_new_in_android_studio_35/exiwmp1/