### PR TITLE
Fade GradesDetailsActivity's appbar to black when dark mode is on

### DIFF
--- a/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/extension/ContextExt.kt
+++ b/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/extension/ContextExt.kt
@@ -1,6 +1,8 @@
 package ca.etsmtl.applets.etsmobile.extension
 
 import android.Manifest
+import android.animation.ArgbEvaluator
+import android.animation.ValueAnimator
 import android.content.Context
 import android.content.res.Configuration
 import android.net.ConnectivityManager
@@ -20,7 +22,7 @@ import model.UserCredentials
 /**
  * Returns true when dark theme is on, false otherwise.
  */
-inline val Context.isDarkMode: Boolean
+inline val Context.isDarkModeOn: Boolean
     get() {
         val uiMode = resources.configuration.uiMode
 
@@ -60,6 +62,21 @@ fun Context.getColorFromAttr(
 ): Int {
     theme.resolveAttribute(attrColor, typedValue, resolveRefs)
     return typedValue.data
+}
+
+fun Context.animateBetweenColors(
+    @ColorRes startColor: Int,
+    @ColorRes endColor: Int,
+    duration: Long,
+    update: (animatedColorValue: Int) -> Unit
+) = with(ValueAnimator.ofObject(
+    ArgbEvaluator(),
+    getColorCompat(startColor),
+    getColorCompat(endColor)
+)) {
+    this.duration = duration
+    addUpdateListener { update(it.animatedValue as Int) }
+    start()
 }
 
 /**

--- a/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/extension/SeanceExt.kt
+++ b/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/extension/SeanceExt.kt
@@ -10,7 +10,7 @@ import model.Seance
  */
 
 fun Seance.generateColor(context: Context): Int {
-    val secondColor = if (context.isDarkMode) {
+    val secondColor = if (context.isDarkModeOn) {
         Color.WHITE
     } else {
         Color.BLACK

--- a/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/presentation/dashboard/card/grades/GradesCardFragment.kt
+++ b/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/presentation/dashboard/card/grades/GradesCardFragment.kt
@@ -5,13 +5,13 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.Toast
-import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.isVisible
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.ViewModelProviders
+import androidx.navigation.fragment.findNavController
 import ca.etsmtl.applets.etsmobile.R
-import ca.etsmtl.applets.etsmobile.presentation.gradesdetails.GradesDetailsActivity
+import ca.etsmtl.applets.etsmobile.presentation.gradesdetails.navigateToGradesDetails
 import ca.etsmtl.applets.etsmobile.util.EventObserver
 import com.google.android.flexbox.FlexDirection
 import com.google.android.flexbox.FlexboxLayoutManager
@@ -60,14 +60,12 @@ class GradesCardFragment : DaggerFragment() {
         recyclerViewCoursesGrades.itemAnimator = FadeInAnimator()
         onCourseClickListener = object : GradesCardAdapter.OnCourseClickListener {
             override fun onCourseClick(cours: Cours, holder: GradesCardAdapter.GradeViewHolder) {
-                requireActivity().let {
-                    GradesDetailsActivity.start(
-                        it as AppCompatActivity,
-                        holder.itemView,
-                        holder.tvCourseSigle,
-                        cours
-                    )
-                }
+                findNavController().navigateToGradesDetails(
+                    requireActivity(),
+                    holder.tvCourseSigle,
+                    holder.itemView,
+                    cours
+                )
             }
         }
         adapter.onCourseClickListener = onCourseClickListener

--- a/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/presentation/grades/GradesFragment.kt
+++ b/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/presentation/grades/GradesFragment.kt
@@ -5,14 +5,14 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.Toast
-import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.isVisible
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.ViewModelProviders
+import androidx.navigation.fragment.findNavController
 import ca.etsmtl.applets.etsmobile.R
 import ca.etsmtl.applets.etsmobile.extension.applyAppTheme
-import ca.etsmtl.applets.etsmobile.presentation.gradesdetails.GradesDetailsActivity
+import ca.etsmtl.applets.etsmobile.presentation.gradesdetails.navigateToGradesDetails
 import ca.etsmtl.applets.etsmobile.util.EventObserver
 import com.google.android.flexbox.FlexDirection
 import com.google.android.flexbox.FlexWrap
@@ -47,14 +47,12 @@ class GradesFragment : DaggerFragment() {
         GradesAdapter(object : GradesAdapter.OnCourseClickListener {
             override fun onCourseClick(cours: Cours, holder: GradesAdapter.CourseGradeViewHolder) {
                 currentCourseShown = cours
-                this@GradesFragment.activity?.let {
-                    GradesDetailsActivity.start(
-                        it as AppCompatActivity,
-                        holder.itemView,
-                        holder.tvCourseSigle,
-                        cours
-                    )
-                }
+                findNavController().navigateToGradesDetails(
+                    requireActivity(),
+                    holder.tvCourseSigle,
+                    holder.itemView,
+                    cours
+                )
             }
         })
     }

--- a/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/presentation/gradesdetails/GradesDetailsActivity.kt
+++ b/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/presentation/gradesdetails/GradesDetailsActivity.kt
@@ -3,14 +3,18 @@ package ca.etsmtl.applets.etsmobile.presentation.gradesdetails
 import android.content.Intent
 import android.graphics.Color
 import android.os.Bundle
+import android.transition.Transition
 import android.transition.TransitionInflater
 import android.view.MenuItem
 import android.view.View
+import androidx.annotation.ColorRes
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.app.ActivityOptionsCompat
+import androidx.core.transition.doOnStart
 import androidx.core.util.Pair
 import androidx.core.view.isVisible
 import ca.etsmtl.applets.etsmobile.R
+import ca.etsmtl.applets.etsmobile.extension.animateBetweenColors
 import ca.etsmtl.applets.etsmobile.extension.toast
 import ca.etsmtl.applets.etsmobile.presentation.BaseActivity
 import kotlinx.android.synthetic.main.activity_grades_details.appBarLayoutGradesDetails
@@ -38,13 +42,13 @@ class GradesDetailsActivity : BaseActivity() {
          */
         fun start(activity: AppCompatActivity, content: View, toolBar: View, cours: Cours) {
             val options =
-                    ActivityOptionsCompat.makeSceneTransitionAnimation(
-                            activity,
-                            Pair.create(content, activity.getString(R.string
-                                    .transition_grades_details_content)),
-                            Pair.create(toolBar, activity.getString(R.string
-                                    .transition_grades_details_toolbar))
-                    )
+                ActivityOptionsCompat.makeSceneTransitionAnimation(
+                    activity,
+                    Pair.create(content, activity.getString(R.string
+                        .transition_grades_details_content)),
+                    Pair.create(toolBar, activity.getString(R.string
+                        .transition_grades_details_toolbar))
+                )
             activity.startActivity(Intent(activity, GradesDetailsActivity::class.java).apply {
                 putExtra(EXTRA_COURS, cours)
             }, options.toBundle())
@@ -93,10 +97,16 @@ class GradesDetailsActivity : BaseActivity() {
     }
 
     private fun setupWindow() = with(window) {
-        val transition = TransitionInflater.from(this@GradesDetailsActivity)
-            .inflateTransition(R.transition.expand_grade_transition)
-        window.sharedElementEnterTransition = transition
-        window.sharedElementExitTransition = transition
+        window.sharedElementEnterTransition = createAppBarTransition(
+            R.color.colorPrimary,
+            R.color.colorToolbar,
+            1000L
+        )
+        window.sharedElementReturnTransition = createAppBarTransition(
+            R.color.colorToolbar,
+            R.color.colorPrimary,
+            resources.getInteger(android.R.integer.config_longAnimTime).toLong()
+        )
 
         decorView.systemUiVisibility = View.SYSTEM_UI_FLAG_LAYOUT_STABLE or
             View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
@@ -143,4 +153,19 @@ class GradesDetailsActivity : BaseActivity() {
 
         super.onBackPressed()
     }
+
+    private fun createAppBarTransition(
+        @ColorRes startColor: Int,
+        @ColorRes endColor: Int,
+        duration: Long
+    ): Transition = TransitionInflater
+        .from(this@GradesDetailsActivity)
+        .inflateTransition(R.transition.expand_grade_transition)
+        .apply {
+            doOnStart {
+                animateBetweenColors(startColor, endColor, duration) { updatedColor ->
+                    appBarLayoutGradesDetails.setBackgroundColor(updatedColor)
+                }
+            }
+        }
 }

--- a/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/presentation/gradesdetails/GradesDetailsActivity.kt
+++ b/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/presentation/gradesdetails/GradesDetailsActivity.kt
@@ -1,6 +1,5 @@
 package ca.etsmtl.applets.etsmobile.presentation.gradesdetails
 
-import android.content.Intent
 import android.graphics.Color
 import android.os.Bundle
 import android.transition.Transition
@@ -8,10 +7,7 @@ import android.transition.TransitionInflater
 import android.view.MenuItem
 import android.view.View
 import androidx.annotation.ColorRes
-import androidx.appcompat.app.AppCompatActivity
-import androidx.core.app.ActivityOptionsCompat
 import androidx.core.transition.doOnStart
-import androidx.core.util.Pair
 import androidx.core.view.isVisible
 import ca.etsmtl.applets.etsmobile.R
 import ca.etsmtl.applets.etsmobile.extension.animateBetweenColors
@@ -29,44 +25,6 @@ import model.Cours
  */
 
 class GradesDetailsActivity : BaseActivity() {
-    companion object {
-        private const val EXTRA_COURS = "ExtraCours"
-
-        /**
-         * Starts [GradesDetailsActivity] with a shared element transition
-         *
-         * @param activity The host activity
-         * @param content View used to for the shared element transition of the background
-         * @param toolBar View used for the shared element transition of the toolbar
-         * @param cours The course selected by the user
-         */
-        fun start(activity: AppCompatActivity, content: View, toolBar: View, cours: Cours) {
-            val options =
-                ActivityOptionsCompat.makeSceneTransitionAnimation(
-                    activity,
-                    Pair.create(content, activity.getString(R.string
-                        .transition_grades_details_content)),
-                    Pair.create(toolBar, activity.getString(R.string
-                        .transition_grades_details_toolbar))
-                )
-            activity.startActivity(Intent(activity, GradesDetailsActivity::class.java).apply {
-                putExtra(EXTRA_COURS, cours)
-            }, options.toBundle())
-        }
-
-        /**
-         * Starts [GradesDetailsActivity] without a shared element transition
-         *
-         * @param activity
-         * @param cours The course selected by the user
-         */
-        fun start(activity: AppCompatActivity, cours: Cours) {
-            activity.startActivity(Intent(activity, GradesDetailsActivity::class.java).apply {
-                putExtra(EXTRA_COURS, cours)
-            })
-        }
-    }
-
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
@@ -76,33 +34,33 @@ class GradesDetailsActivity : BaseActivity() {
 
         setupToolbar()
 
-        with(intent?.extras) {
-            with(this?.getParcelable(EXTRA_COURS) as? Cours) {
-                if (this == null) {
-                    toast(R.string.error)
-                    onBackPressed()
-                } else {
-                    if (savedInstanceState == null) {
-                        addFragment(this)
-                    }
+        val bundle = intent?.extras
 
-                    supportActionBar?.let {
-                        it.title = sigle
-                    }
-                    tvGradesDetailsCourseName.text = titreCours
-                    tvGradesDetailsGroup.text = String.format(getString(R.string.text_group), groupe)
-                }
+        if (bundle == null) {
+            toast(R.string.error)
+            onBackPressed()
+        } else {
+            val cours = GradesDetailsActivityArgs.fromBundle(bundle).course
+
+            if (savedInstanceState == null) {
+                addFragment(cours)
             }
+
+            supportActionBar?.let {
+                it.title = cours.sigle
+            }
+            tvGradesDetailsCourseName.text = cours.titreCours
+            tvGradesDetailsGroup.text = String.format(getString(R.string.text_group), cours.groupe)
         }
     }
 
     private fun setupWindow() = with(window) {
-        window.sharedElementEnterTransition = createAppBarTransition(
+        window.sharedElementEnterTransition = createTransition(
             R.color.colorPrimary,
             R.color.colorToolbar,
             1000L
         )
-        window.sharedElementReturnTransition = createAppBarTransition(
+        window.sharedElementReturnTransition = createTransition(
             R.color.colorToolbar,
             R.color.colorPrimary,
             resources.getInteger(android.R.integer.config_longAnimTime).toLong()
@@ -154,7 +112,17 @@ class GradesDetailsActivity : BaseActivity() {
         super.onBackPressed()
     }
 
-    private fun createAppBarTransition(
+    /**
+     * Returns the enter/exit [Transition]
+     *
+     * The app's bar color smoothly changes between [startColor] and [endColor].
+     *
+     * @param startColor The app bar's start color
+     * @param endColor The app bar's end color
+     * @param duration The app's bar color transition duration in milliseconds
+     *
+     */
+    private fun createTransition(
         @ColorRes startColor: Int,
         @ColorRes endColor: Int,
         duration: Long

--- a/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/presentation/gradesdetails/GradesDetailsActivity.kt
+++ b/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/presentation/gradesdetails/GradesDetailsActivity.kt
@@ -1,6 +1,7 @@
 package ca.etsmtl.applets.etsmobile.presentation.gradesdetails
 
 import android.content.Intent
+import android.graphics.Color
 import android.os.Bundle
 import android.transition.TransitionInflater
 import android.view.MenuItem
@@ -10,11 +11,13 @@ import androidx.core.app.ActivityOptionsCompat
 import androidx.core.util.Pair
 import androidx.core.view.isVisible
 import ca.etsmtl.applets.etsmobile.R
-import ca.etsmtl.applets.etsmobile.extension.getColorCompat
-import ca.etsmtl.applets.etsmobile.extension.isDarkMode
 import ca.etsmtl.applets.etsmobile.extension.toast
 import ca.etsmtl.applets.etsmobile.presentation.BaseActivity
-import kotlinx.android.synthetic.main.activity_grades_details.*
+import kotlinx.android.synthetic.main.activity_grades_details.appBarLayoutGradesDetails
+import kotlinx.android.synthetic.main.activity_grades_details.containerTvGradesDetailsSubtitle
+import kotlinx.android.synthetic.main.activity_grades_details.toolbar
+import kotlinx.android.synthetic.main.activity_grades_details.tvGradesDetailsCourseName
+import kotlinx.android.synthetic.main.activity_grades_details.tvGradesDetailsGroup
 import model.Cours
 
 /**
@@ -63,17 +66,11 @@ class GradesDetailsActivity : BaseActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        val transition = TransitionInflater.from(this).inflateTransition(R.transition.expand_grade_transition)
-        window.sharedElementEnterTransition = transition
-        window.sharedElementExitTransition = transition
+        setupWindow()
 
         setContentView(R.layout.activity_grades_details)
 
         setupToolbar()
-
-        if (isDarkMode) {
-            window.statusBarColor = getColorCompat(R.color.etsRougeClair)
-        }
 
         with(intent?.extras) {
             with(this?.getParcelable(EXTRA_COURS) as? Cours) {
@@ -93,6 +90,17 @@ class GradesDetailsActivity : BaseActivity() {
                 }
             }
         }
+    }
+
+    private fun setupWindow() = with(window) {
+        val transition = TransitionInflater.from(this@GradesDetailsActivity)
+            .inflateTransition(R.transition.expand_grade_transition)
+        window.sharedElementEnterTransition = transition
+        window.sharedElementExitTransition = transition
+
+        decorView.systemUiVisibility = View.SYSTEM_UI_FLAG_LAYOUT_STABLE or
+            View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
+        statusBarColor = Color.TRANSPARENT
     }
 
     private fun setupToolbar() {
@@ -131,10 +139,6 @@ class GradesDetailsActivity : BaseActivity() {
                 remove(it)
                 commit()
             }
-        }
-
-        if (isDarkMode) {
-            window.statusBarColor = getColorCompat(R.color.colorPrimaryDark)
         }
 
         super.onBackPressed()

--- a/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/presentation/gradesdetails/NavControllerExt.kt
+++ b/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/presentation/gradesdetails/NavControllerExt.kt
@@ -1,0 +1,38 @@
+package ca.etsmtl.applets.etsmobile.presentation.gradesdetails
+
+import android.app.Activity
+import android.view.View
+import androidx.core.app.ActivityOptionsCompat
+import androidx.core.util.Pair
+import androidx.navigation.ActivityNavigatorExtras
+import androidx.navigation.NavController
+import ca.etsmtl.applets.etsmobile.R
+import ca.etsmtl.applets.etsmobile.presentation.student.StudentFragmentDirections
+import model.Cours
+
+/**
+ * Created by Sonphil on 28-08-19.
+ */
+
+fun NavController.navigateToGradesDetails(
+    activity: Activity,
+    toolbar: View,
+    contentView: View,
+    cours: Cours
+) {
+    val action = StudentFragmentDirections.actionToActivityGradesDetails(cours)
+    val toolbarPair = Pair.create(
+        toolbar,
+        activity.getString(R.string.transition_grades_details_toolbar)
+    )
+    val contentPair = Pair.create(
+        contentView,
+        activity.getString(R.string.transition_grades_details_content)
+    )
+    val options = ActivityOptionsCompat.makeSceneTransitionAnimation(
+        activity, toolbarPair, contentPair
+    )
+    val extras = ActivityNavigatorExtras(options)
+
+    navigate(action, extras)
+}

--- a/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/presentation/main/MainActivity.kt
+++ b/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/presentation/main/MainActivity.kt
@@ -25,8 +25,8 @@ import kotlinx.android.synthetic.main.activity_main.toolbar
 import javax.inject.Inject
 
 /**
- * A screen which displays a bottom navigation view and wrapper for fragment. The user can
- * select items on the bottom navigation view to switch between fragments.
+ * A screen which displays an app bar, a bottom navigation view and wrapper for fragment. The user
+ * can select items on the bottom navigation view to switch between fragments.
  *
  * Created by Sonphil on 24-02-18.
  */

--- a/android/app/src/main/res/drawable/grade_app_bar_color_transition.xml
+++ b/android/app/src/main/res/drawable/grade_app_bar_color_transition.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<transition xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:drawable="@color/colorPrimary" />
+    <item android:drawable="@color/etsGrisFonce" />
+</transition>

--- a/android/app/src/main/res/layout/activity_grades_details.xml
+++ b/android/app/src/main/res/layout/activity_grades_details.xml
@@ -8,11 +8,27 @@
     android:orientation="vertical"
     tools:context=".presentation.gradesdetails.GradesDetailsActivity">
 
+    <FrameLayout
+        android:id="@+id/containerGradesDetails"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_weight="1"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior">
+
+        <!-- Background for shared element transition -->
+        <View
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:background="@android:color/transparent"
+            android:transitionName="@string/transition_grades_details_content" />
+    </FrameLayout>
+
     <com.google.android.material.appbar.AppBarLayout
         android:id="@+id/appBarLayoutGradesDetails"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:background="@color/colorPrimary"
+        android:fitsSystemWindows="true"
         android:transitionName="@string/transition_grades_details_toolbar">
 
         <com.google.android.material.appbar.CollapsingToolbarLayout
@@ -65,19 +81,4 @@
                 app:layout_collapseMode="pin" />
         </com.google.android.material.appbar.CollapsingToolbarLayout>
     </com.google.android.material.appbar.AppBarLayout>
-
-    <FrameLayout
-        android:id="@+id/containerGradesDetails"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:layout_weight="1"
-        app:layout_behavior="@string/appbar_scrolling_view_behavior">
-
-        <!-- Background for shared element transition -->
-        <View
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:background="@android:color/transparent"
-            android:transitionName="@string/transition_grades_details_content" />
-    </FrameLayout>
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/android/app/src/main/res/layout/activity_grades_details.xml
+++ b/android/app/src/main/res/layout/activity_grades_details.xml
@@ -27,19 +27,19 @@
         android:id="@+id/appBarLayoutGradesDetails"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:background="@color/colorPrimary"
         android:fitsSystemWindows="true"
         android:transitionName="@string/transition_grades_details_toolbar">
 
         <com.google.android.material.appbar.CollapsingToolbarLayout
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            app:collapsedTitleTextAppearance="@style/TextAppearance.AppTheme.CollapsingToolbar.Collapsed"
-            app:contentScrim="@color/colorPrimary"
+            app:collapsedTitleTextAppearance="@style/TextAppearance.GradesDetailsTheme.CollapsingToolbar.Collapsed"
+            app:contentScrim="@color/colorToolbar"
             app:expandedTitleGravity="center_vertical"
             app:expandedTitleMarginStart="19dp"
-            app:expandedTitleTextAppearance="@style/TextAppearance.AppTheme.CollapsingToolbar.Expanded"
-            app:layout_scrollFlags="scroll|exitUntilCollapsed|snap">
+            app:expandedTitleTextAppearance="@style/TextAppearance.GradesDetailsTheme.CollapsingToolbar.Expanded"
+            app:layout_scrollFlags="scroll|exitUntilCollapsed|snap"
+            app:statusBarScrim="@color/colorToolbar">
 
             <LinearLayout
                 android:id="@+id/containerTvGradesDetailsSubtitle"

--- a/android/app/src/main/res/layout/activity_main.xml
+++ b/android/app/src/main/res/layout/activity_main.xml
@@ -13,7 +13,6 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:animateLayoutChanges="true"
-        android:background="@color/colorToolbar"
         app:expanded="false"
         tools:expanded="true">
 

--- a/android/app/src/main/res/navigation/nav_graph_main.xml
+++ b/android/app/src/main/res/navigation/nav_graph_main.xml
@@ -51,7 +51,22 @@
         android:id="@+id/fragmentStudent"
         android:name="ca.etsmtl.applets.etsmobile.presentation.student.StudentFragment"
         android:label="@string/title_student"
-        tools:layout="@layout/fragment_student" />
+        tools:layout="@layout/fragment_student">
+    </fragment>
+    <action
+        android:id="@+id/action_to_activityGradesDetails"
+        app:destination="@id/activityGradesDetails">
+        <argument
+            android:name="course"
+            app:argType="model.Cours" />
+    </action>
+    <activity
+        android:id="@+id/activityGradesDetails"
+        android:name="ca.etsmtl.applets.etsmobile.presentation.gradesdetails.GradesDetailsActivity">
+        <argument
+            android:name="course"
+            app:argType="model.Cours" />
+    </activity>
     <fragment
         android:id="@+id/fragmentEts"
         android:name="ca.etsmtl.applets.etsmobile.presentation.ets.EtsFragment"

--- a/android/app/src/main/res/values/colors.xml
+++ b/android/app/src/main/res/values/colors.xml
@@ -26,7 +26,7 @@
     </color>
     <color name="background_material_dark">#ffffff</color>
 
-    <color name="colorToolbar">#121212</color>
+    <color name="colorToolbar">#212121</color>
     <color name="colorToolbarAccent">@android:color/white</color>
     <color name="colorSwipeRefreshBg">@color/etsNoir</color>
     <color name="colorDialogBg">@color/etsNoir</color>

--- a/android/app/src/main/res/values/styles.xml
+++ b/android/app/src/main/res/values/styles.xml
@@ -90,7 +90,6 @@
         <item name="rippleColor">@color/colorPrimary</item>
     </style>
 
-
     <style name="Widget.AppTheme.Dashboard.Card.Applets.Button" parent="Widget.MaterialComponents.Button.TextButton">
         <item name="android:textColor">@android:color/white</item>
         <item name="rippleColor">@android:color/white</item>

--- a/android/app/src/main/res/values/styles.xml
+++ b/android/app/src/main/res/values/styles.xml
@@ -31,14 +31,14 @@
         <item name="colorControlNormal">@android:color/white</item>
     </style>
 
-    <style name="TextAppearance.AppTheme.CollapsingToolbar.Expanded" parent="TextAppearance.MaterialComponents.Headline6">
+    <style name="TextAppearance.GradesDetailsTheme.CollapsingToolbar.Expanded" parent="TextAppearance.MaterialComponents.Headline6">
         <item name="android:textSize">25sp</item>
         <item name="android:textColor">@android:color/white</item>
     </style>
 
-    <style name="TextAppearance.AppTheme.CollapsingToolbar.Collapsed" parent="TextAppearance.MaterialComponents.Headline6">
+    <style name="TextAppearance.GradesDetailsTheme.CollapsingToolbar.Collapsed" parent="TextAppearance.MaterialComponents.Headline6">
         <item name="android:textSize">20sp</item>
-        <item name="android:textColor">@android:color/white</item>
+        <item name="android:textColor">@color/colorToolbarAccent</item>
     </style>
 
     <style name="WindowAnimationTransition">


### PR DESCRIPTION
- Fade `GradesDetailsActivity`'s appbar on transition start
- Use Navigation component to navigate to `GradesDetailsActivity` instead of using an `Intent` and `startActivity`