### PR TITLE
Fix webview crash occurring on Lollipop

### DIFF
--- a/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/view/LollipopFixedWebView.kt
+++ b/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/view/LollipopFixedWebView.kt
@@ -1,0 +1,25 @@
+package ca.etsmtl.applets.etsmobile.view
+
+import android.content.Context
+import android.content.res.Configuration
+import android.os.Build
+import android.util.AttributeSet
+import android.webkit.WebView
+
+private fun getFixedContext(context: Context) = if (Build.VERSION.SDK_INT in 21..22) {
+    context.createConfigurationContext(Configuration())
+} else {
+    context
+}
+
+/**
+ * Subclass used to prevent crashes on Lollipop
+ *
+ * @see <a href="https://issuetracker.google.com/issues/141132133">https://issuetracker.google.com/issues/141132133</a>
+ */
+class LollipopFixedWebView @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+    defStyleAttr: Int = 0,
+    defStyleRes: Int = 0
+) : WebView(getFixedContext(context), attrs, defStyleAttr, defStyleRes)

--- a/android/app/src/main/res/layout/fragment_security_detail.xml
+++ b/android/app/src/main/res/layout/fragment_security_detail.xml
@@ -4,7 +4,7 @@
     android:layout_height="match_parent"
     app:layout_behavior="@string/appbar_scrolling_view_behavior">
 
-    <WebView
+    <ca.etsmtl.applets.etsmobile.view.LollipopFixedWebView
         android:id="@+id/webView"
         android:layout_width="match_parent"
         android:layout_height="match_parent"

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ buildscript {
             "ktor": "1.2.3",
             "leakcanary": "2.0-beta-3",
             "lifecycle": "2.1.0",
-            "lifecycle_viewmodel_ktx": "2.2.0-alpha04",
+            "lifecycle_viewmodel_ktx": "2.2.0-alpha05",
             "material_components": "1.1.0-alpha10",
             "materialprogressview": "1.0.6",
             "mockito": "2.28.2",


### PR DESCRIPTION
Fix crash occurring on Lollipop when the security details are opened with a `WebView`

cf. https://issuetracker.google.com/issues/141132133