### PR TITLE
Remove schedule bottom padding

### DIFF
--- a/android/app/src/main/res/layout/fragment_schedule.xml
+++ b/android/app/src/main/res/layout/fragment_schedule.xml
@@ -7,7 +7,6 @@
     android:layout_height="match_parent"
     android:layout_marginBottom="@dimen/design_bottom_navigation_height"
     android:orientation="vertical"
-    android:paddingBottom="@dimen/design_bottom_navigation_height"
     tools:context="ca.etsmtl.applets.etsmobile.presentation.schedule.ScheduleFragment"
     tools:ignore="PrivateResource">
 


### PR DESCRIPTION
The header could swiped up and that would leave a space at the bottom of the schedule.

Fix #211