### PR TITLE
Add dependencies needed to build for iOS

### DIFF
--- a/shared/build.gradle
+++ b/shared/build.gradle
@@ -82,6 +82,10 @@ kotlin {
             dependencies {
                 implementation "org.jetbrains.kotlinx:kotlinx-serialization-runtime-native:$versions.kotlinx_serialization"
                 implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core-native:$versions.coroutines"
+
+                //Ktor
+                implementation "io.ktor:ktor-client-ios:$versions.ktor"
+                implementation "io.ktor:ktor-client-serialization-native:$versions.ktor"
             }
         }
     }


### PR DESCRIPTION
Add *ktor serialization* and *ktor-client* for iOS in gradle to be able to compile.