### PR TITLE
Fix appbar's extra padding when user switched left StudentFragment rapidly

### DIFF
--- a/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/presentation/login/LoginFragment.kt
+++ b/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/presentation/login/LoginFragment.kt
@@ -141,9 +141,10 @@ class LoginFragment : DaggerFragment() {
             when (it.id) {
                 R.id.btnSignIn -> { setCredentialsFieldsAndSubmitCredentials() }
                 R.id.btnForgotPassword -> {
-                    context?.let {
-                        Uri.parse(getString(R.string.uri_password_forgotten)).open(it)
-                    }
+                    Uri.parse(getString(R.string.uri_password_forgotten)).open(requireContext())
+                }
+                R.id.btnApplets -> {
+                    Uri.parse(getString(R.string.uri_applets_website)).open(requireContext())
                 }
             }
         }.apply {

--- a/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/presentation/student/StudentFragment.kt
+++ b/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/presentation/student/StudentFragment.kt
@@ -7,7 +7,6 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.core.view.isVisible
 import ca.etsmtl.applets.etsmobile.R
-import ca.etsmtl.applets.etsmobile.extension.fadeTo
 import ca.etsmtl.applets.etsmobile.presentation.main.MainActivity
 import com.google.android.material.tabs.TabLayout
 import dagger.android.support.DaggerFragment
@@ -44,7 +43,7 @@ class StudentFragment : DaggerFragment() {
                 showTabsRunnable = Runnable {
                     viewPagerStudent.adapter = StudentPagerAdapter(activity, childFragmentManager)
                     tabLayout.setupWithViewPager(viewPagerStudent)
-                    tabLayout.fadeTo(View.VISIBLE)
+                    tabLayout.isVisible = true
                 }
                 showTabsHandler.postDelayed(
                     showTabsRunnable,


### PR DESCRIPTION
- Fix `AppBarLayout` extra padding
When `StudentFragment` is shown, the `AppBarLayout` expands and the `TabLayout` becomes visible. However, if the user left `StudentFragment right away, the `AppBarLayout` could remain in expanded state like so:

<img src="https://user-images.githubusercontent.com/22182973/66875235-9a48f800-ef7b-11e9-89f8-dba6d48902fd.png" width="300"/>

- Navigate to App|ETS' website when the logo is clicked in the login screen
