### PR TITLE
Remove blue color for emergency procedures

### DIFF
--- a/lib/ui/views/security_view.dart
+++ b/lib/ui/views/security_view.dart
@@ -66,7 +66,8 @@ class _SecurityViewState extends State<SecurityView> {
                   child: InkWell(
                     splashColor: Colors.red.withAlpha(50),
                     onTap: () => Utils.launchURL(
-                            'tel:${AppIntl.of(context).security_emergency_number}', AppIntl.of(context))
+                            'tel:${AppIntl.of(context).security_emergency_number}',
+                            AppIntl.of(context))
                         .catchError((error) {
                       ScaffoldMessenger.of(context).showSnackBar(
                           SnackBar(content: Text(error.toString())));
@@ -99,27 +100,30 @@ class _SecurityViewState extends State<SecurityView> {
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: List.generate(
                       model.emergencyProcedureList.length,
-                      (index) => TextButton(
-                        onPressed: () => Navigator.push(
-                            context,
-                            MaterialPageRoute(
-                                builder: (context) => EmergencyView(
-                                    model.emergencyProcedureList[index].title,
-                                    model.emergencyProcedureList[index]
-                                        .detail))),
-                        child: Row(
-                          mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                          children: [
-                            Padding(
-                              padding:
-                                  const EdgeInsets.symmetric(vertical: 16.0),
-                              child: Text(
-                                model.emergencyProcedureList[index].title,
-                                style: const TextStyle(fontSize: 18),
+                      (index) => Card(
+                        child: InkWell(
+                          splashColor: Colors.red.withAlpha(50),
+                          onTap: () => Navigator.push(
+                              context,
+                              MaterialPageRoute(
+                                  builder: (context) => EmergencyView(
+                                      model.emergencyProcedureList[index].title,
+                                      model.emergencyProcedureList[index]
+                                          .detail))),
+                          child: Row(
+                            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                            children: [
+                              Padding(
+                                padding:
+                                    const EdgeInsets.symmetric(vertical: 16.0),
+                                child: Text(
+                                  model.emergencyProcedureList[index].title,
+                                  style: const TextStyle(fontSize: 18),
+                                ),
                               ),
-                            ),
-                            const Icon(Icons.arrow_forward_ios),
-                          ],
+                              const Icon(Icons.arrow_forward_ios),
+                            ],
+                          ),
                         ),
                       ),
                     ),

--- a/lib/ui/views/security_view.dart
+++ b/lib/ui/views/security_view.dart
@@ -80,12 +80,17 @@ class _SecurityViewState extends State<SecurityView> {
                     ),
                   ),
                 ),
-                ListTile(
-                  leading: const Icon(Icons.phone, size: 30),
-                  title:
-                      Text(AppIntl.of(context).security_emergency_intern_call),
-                  subtitle: Text(
-                      AppIntl.of(context).security_emergency_intern_number),
+                Card(
+                  child: InkWell(
+                    splashColor: Colors.red.withAlpha(50),
+                    child: ListTile(
+                      leading: const Icon(Icons.phone, size: 30),
+                      title: Text(
+                          AppIntl.of(context).security_emergency_intern_call),
+                      subtitle: Text(
+                          AppIntl.of(context).security_emergency_intern_number),
+                    ),
+                  ),
                 ),
                 Padding(
                   padding: const EdgeInsets.all(8.0),

--- a/lib/ui/views/security_view.dart
+++ b/lib/ui/views/security_view.dart
@@ -114,8 +114,8 @@ class _SecurityViewState extends State<SecurityView> {
                             mainAxisAlignment: MainAxisAlignment.spaceBetween,
                             children: [
                               Padding(
-                                padding:
-                                    const EdgeInsets.symmetric(vertical: 16.0),
+                                padding: const EdgeInsets.only(
+                                    top: 16.0, bottom: 16.0, left: 16.0),
                                 child: Text(
                                   model.emergencyProcedureList[index].title,
                                   style: const TextStyle(fontSize: 18),

--- a/lib/ui/views/security_view.dart
+++ b/lib/ui/views/security_view.dart
@@ -81,15 +81,14 @@ class _SecurityViewState extends State<SecurityView> {
                   ),
                 ),
                 Card(
-                  child: InkWell(
-                    splashColor: Colors.red.withAlpha(50),
-                    child: ListTile(
-                      leading: const Icon(Icons.phone, size: 30),
-                      title: Text(
-                          AppIntl.of(context).security_emergency_intern_call),
-                      subtitle: Text(
-                          AppIntl.of(context).security_emergency_intern_number),
-                    ),
+                  elevation: 0,
+                  color: Colors.transparent,
+                  child: ListTile(
+                    leading: const Icon(Icons.phone, size: 30),
+                    title: Text(
+                        AppIntl.of(context).security_emergency_intern_call),
+                    subtitle: Text(
+                        AppIntl.of(context).security_emergency_intern_number),
                   ),
                 ),
                 Padding(

--- a/test/ui/views/security_view_test.dart
+++ b/test/ui/views/security_view_test.dart
@@ -37,7 +37,8 @@ void main() {
         final Finder phoneButton = find.widgetWithText(Card, 'Emergency call');
         expect(phoneButton, findsOneWidget);
 
-        final Finder emergencyList = find.byType(TextButton);
+        final Finder emergencyList =
+            find.widgetWithIcon(Card, Icons.arrow_forward_ios);
         expect(emergencyList, findsNWidgets(emergencyProcedures(intl).length));
       });
     });


### PR DESCRIPTION
Fixed by swapping the TextButton to a Card widget.
dark theme:
<image src="https://user-images.githubusercontent.com/25663435/111914046-d91f8f00-8a46-11eb-8ac7-54302aa9886f.png" width="200"/>
light theme:
<image src="https://user-images.githubusercontent.com/25663435/111914055-e5a3e780-8a46-11eb-8f76-438457203333.png" width="200"/>

closes #56