### PR TITLE
Fix calendar locale and typo.

### DIFF
--- a/lib/core/viewmodels/schedule_viewmodel.dart
+++ b/lib/core/viewmodels/schedule_viewmodel.dart
@@ -35,6 +35,9 @@ class ScheduleViewModel extends FutureViewModel<List<CourseActivity>> {
   /// Day currently selected
   DateTime selectedDate = DateTime.now();
 
+  /// Get current locale
+  Locale get locale => _settingsManager.locale;
+
   ScheduleViewModel({@required AppIntl intl, DateTime initialSelectedDate})
       : _appIntl = intl,
         selectedDate = initialSelectedDate ?? DateTime.now();

--- a/lib/l10n/intl_fr.arb
+++ b/lib/l10n/intl_fr.arb
@@ -55,7 +55,7 @@
   "schedule_settings_starting_weekday_friday": "Vendredi",
   "schedule_settings_starting_weekday_saturday": "Samedi",
   "schedule_settings_starting_weekday_sunday": "Dimanche",
-  "schedule_no_event": "Aucun évènements à l'horaire.",
+  "schedule_no_event": "Aucun évènement à l'horaire.",
 
   "grades_title": "Notes",
   "grades_msg_no_grades": "Aucune note disponible\nTirer pour recharger",

--- a/lib/ui/views/schedule_view.dart
+++ b/lib/ui/views/schedule_view.dart
@@ -38,8 +38,6 @@ class _ScheduleViewState extends State<ScheduleView>
 
   static const Color _defaultColor = Color(0xff76859B);
 
-  final DateFormat _dateFormat = DateFormat.MMMMEEEEd();
-
   CalendarController _calendarController;
 
   AnimationController _animationController;
@@ -91,7 +89,9 @@ class _ScheduleViewState extends State<ScheduleView>
                       const Divider(indent: 8.0, endIndent: 8.0, thickness: 1),
                       const SizedBox(height: 6.0),
                       Center(
-                          child: Text(_dateFormat.format(model.selectedDate),
+                          child: Text(
+                              DateFormat.MMMMEEEEd(model.locale.toString())
+                                  .format(model.selectedDate),
                               style: Theme.of(context).textTheme.headline5)),
                       const SizedBox(height: 2.0),
                       Expanded(
@@ -137,6 +137,7 @@ class _ScheduleViewState extends State<ScheduleView>
         //TODO uncomment when https://github.com/aleksanderwozniak/table_calendar/issues/164 is close
         // startingDayOfWeek: model.settings[PreferencesFlag.scheduleSettingsStartWeekday] as StartingDayOfWeek,
         startingDayOfWeek: StartingDayOfWeek.monday,
+        locale: model.locale.toLanguageTag(),
         initialSelectedDay: widget.initialDay ?? DateTime.now(),
         weekendDays: const [],
         headerStyle: const HeaderStyle(

--- a/test/mock/managers/settings_manager_mock.dart
+++ b/test/mock/managers/settings_manager_mock.dart
@@ -1,4 +1,5 @@
 // FLUTTER / DART / THIRD-PARTIES
+import 'package:flutter/cupertino.dart';
 import 'package:mockito/mockito.dart';
 
 // MANAGER
@@ -9,22 +10,32 @@ import 'package:notredame/core/constants/preferences_flags.dart';
 
 class SettingsManagerMock extends Mock implements SettingsManager {
   /// Stub the [getScheduleSettings] function of [mock], when called return [toReturn].
-  static void stubGetScheduleSettings(SettingsManagerMock mock, {Map<PreferencesFlag, dynamic> toReturn = const {}}) {
+  static void stubGetScheduleSettings(SettingsManagerMock mock,
+      {Map<PreferencesFlag, dynamic> toReturn = const {}}) {
     when(mock.getScheduleSettings()).thenAnswer((_) async => toReturn);
   }
 
   /// Stub the [setString] function of [mock], when called with [flag] return [toReturn].
-  static void stubSetString(SettingsManagerMock mock, PreferencesFlag flag, {bool toReturn = true}) {
+  static void stubSetString(SettingsManagerMock mock, PreferencesFlag flag,
+      {bool toReturn = true}) {
     when(mock.setString(flag, any)).thenAnswer((_) async => toReturn);
   }
 
   /// Stub the [getString] function of [mock], when called with [flag] return [toReturn].
-  static void stubGetString(SettingsManagerMock mock, PreferencesFlag flag, {String toReturn = 'test'}) {
+  static void stubGetString(SettingsManagerMock mock, PreferencesFlag flag,
+      {String toReturn = 'test'}) {
     when(mock.getString(flag)).thenAnswer((_) async => toReturn);
   }
 
   /// Stub the [setBool] function of [mock], when called with [flag] return [toReturn].
-  static void stubSetBool(SettingsManagerMock mock, PreferencesFlag flag, {bool toReturn = true}) {
+  static void stubSetBool(SettingsManagerMock mock, PreferencesFlag flag,
+      {bool toReturn = true}) {
     when(mock.setBool(flag, any)).thenAnswer((_) async => toReturn);
+  }
+
+  /// Stub the [locale] function of [mock], when called return [toReturn].
+  static void stubLocale(SettingsManagerMock mock,
+      {Locale toReturn = const Locale('en')}) {
+    when(mock.locale).thenReturn(toReturn);
   }
 }

--- a/test/ui/views/schedule_view_test.dart
+++ b/test/ui/views/schedule_view_test.dart
@@ -82,6 +82,8 @@ void main() {
       settingsManager = setupSettingsManagerMock();
       courseRepository = setupCourseRepositoryMock();
 
+      SettingsManagerMock.stubLocale(settingsManager as SettingsManagerMock);
+
       settings = {
         PreferencesFlag.scheduleSettingsCalendarFormat: CalendarFormat.week,
         PreferencesFlag.scheduleSettingsStartWeekday: StartingDayOfWeek.monday,


### PR DESCRIPTION
Will close #89.

The calendar now follows the french date format when in french!

![Screen Shot 2021-04-01 at 2 26 16 PM](https://user-images.githubusercontent.com/22211097/113337772-3abce480-92f6-11eb-8cca-348f60d012e9.png)
