### PR TITLE
Create labels with PR size on every open PR

### DIFF
--- a/.github/workflows/main-workflow.yaml
+++ b/.github/workflows/main-workflow.yaml
@@ -157,6 +157,20 @@ jobs:
           namedLogo: flutter
           color: green
 
+  create-labels:
+    name: Create labels on PR
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run the Github actions
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: alexromer0/pull-request-labeler@2.1.1
+        with:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          xs_limit: '50'
+          sm_limit: '100'
+          md_limit: '300'
+          lg_limit: '600'
+
 #      Disable these steps for now. Will enable them when we will think of a way to upload lcov.base.info somewhere
 #      - name: Commit coverage file
 #        id: commit


### PR DESCRIPTION
If we decided to add that to the main-workflow it would look a bit like that. This PR will be an `xs-pr` by definition.

Go check out my fork PR page for an example with each labels: https://github.com/MysticFragilist/Notre-Dame/pulls
(don't look at the other workflow it should not work)

I currently used the custom settings from the actions given in the issue mention by @apomalyn:
- xs: changes nb <= 50
- sm: 51 <= changes nb <= 100
- md: 101 <= changes nb <= 300
- lg: 301 <= changes nb <= 500
- xl: 501 <= changes nb

close #230 