### PR TITLE
Modified procedure to extract env variables and decrypt files

### DIFF
--- a/README.fr.md
+++ b/README.fr.md
@@ -35,11 +35,12 @@ _Note: Ce guide est aussi disponible en: [English](https://github.com/ApplETS/No
 
 ## Avant de démarrer le code
 
-- Pour avoir accès a certaines fonctionnalités vous allez avoir besoin du certificat de SignetsAPI, ces fichiers sont encrypté.
-  Pour les décrypter vous allez devoir exécuter le script `env_variables.sh` (disponible uniquement sur le Google Drive du club), puis exécuter les commandes suivantes:
+- Pour avoir accès a certaines fonctionnalités vous allez avoir besoin du certificat de SignetsAPI, la clef Google Drive., etc. , ces fichiers sont encrypté.
+  Pour les décrypter vous allez devoir exécuter le script `env_variables.sh` (disponible uniquement sur le Google Drive du club), 
+- puis exécuter les commandes suivantes à la racine du projet:
 ```bash
-chmod +x ./scripts/decrypt.sh
-./scripts/decrypt.sh
+chmod +x ./env_variables.sh
+./env_variables.sh
 ```
 
 ## Démarrer le code

--- a/README.md
+++ b/README.md
@@ -40,9 +40,9 @@ _Note: This guide is also available in: [Français](https://github.com/ApplETS/N
 
 - To access some features you will need the SignetsAPI certificate, these files are encrypted. To decrypt them you will have to do two simple steps:
 
-1- You need to copy the script `env_variables.sh` (only available on the Google Drive of the club) to the root folder of your project, then run:
+You need to copy the script `env_variables.sh` (only available on the Google Drive of the club) to the root folder of your project, then run:
 
-```
+```sh
 chmod +x ./scripts/decrypt.sh
 chmod +x ./env_variables.sh
 ./env_variables.sh

--- a/README.md
+++ b/README.md
@@ -38,12 +38,14 @@ _Note: This guide is also available in: [Français](https://github.com/ApplETS/N
 
 ## Before running the code
 
-- To access some features you will need the SignetsAPI certificate, these files are encrypted. To decrypt them you will
-  need to execute the `env_variables.sh` script (only available on the Google Drive of the club), then run:
+- To access some features you will need the SignetsAPI certificate, these files are encrypted. To decrypt them you will have to do two simple steps:
+
+1- You need to copy the script `env_variables.sh` (only available on the Google Drive of the club) to the root folder of your project, then run:
 
 ```
 chmod +x ./scripts/decrypt.sh
-./scripts/decrypt.sh
+chmod +x ./env_variables.sh
+./env_variables.sh
 ```
 
 ## Run the code


### PR DESCRIPTION
There was an error while installing the repo on @xeniya-nalivaiko computer. I redid on my computer the steps in `README.md` and this was in fact an error (On windows at least).

Basically, the script `env_variables.sh` when executed, exported 2 variables, but the scope of those variables were only inside the file itself. So when the scripts finished the variables weren't exported in the sh session and they were empty when red from `./scripts/decrypt.sh`

So an easy workaround was to call directly `./scripts/decrypt.sh` from the `env_variables.sh` so it is easier for newcomers to install. I modified the procedure in readme, added the new line in the google drive env_var file and did a PR to discuss the changes, I don't know if there is a better way to handle this. Let me know!