### PR TITLE
Issues/171 profile text white on white

### DIFF
--- a/lib/ui/views/more_view.dart
+++ b/lib/ui/views/more_view.dart
@@ -39,6 +39,14 @@ class _MoreViewState extends State<MoreView> {
     });
   }
 
+  /// Returns right icon color for discovery depending on theme.
+  Widget getProperIconAccordingToTheme(IconData icon) {
+    return (Theme.of(context).brightness == Brightness.dark &&
+            isDiscoveryOverlayActive)
+        ? Icon(icon, color: Colors.black)
+        : Icon(icon);
+  }
+
   /// License text box
   List<Widget> aboutBoxChildren(BuildContext context) {
     final textStyle = Theme.of(context).textTheme.bodyText2;
@@ -96,10 +104,7 @@ class _MoreViewState extends State<MoreView> {
                   title: Text(AppIntl.of(context).more_report_bug),
                   leading: _buildDiscoveryFeatureDescriptionWidget(
                       context,
-                      (Theme.of(context).brightness == Brightness.dark &&
-                              isDiscoveryOverlayActive)
-                          ? const Icon(Icons.bug_report, color: Colors.black)
-                          : const Icon(Icons.bug_report),
+                      getProperIconAccordingToTheme(Icons.bug_report),
                       DiscoveryIds.detailsMoreBugReport,
                       model),
                   onTap: () => BetterFeedback.of(context).show((
@@ -115,11 +120,7 @@ class _MoreViewState extends State<MoreView> {
                   title: Text(AppIntl.of(context).more_contributors),
                   leading: _buildDiscoveryFeatureDescriptionWidget(
                       context,
-                      (Theme.of(context).brightness == Brightness.dark &&
-                              isDiscoveryOverlayActive)
-                          ? const Icon(Icons.people_outline,
-                              color: Colors.black)
-                          : const Icon(Icons.people_outline),
+                      getProperIconAccordingToTheme(Icons.people_outline),
                       DiscoveryIds.detailsMoreContributors,
                       model),
                   onTap: () => model.navigationService
@@ -153,10 +154,7 @@ class _MoreViewState extends State<MoreView> {
                   title: Text(AppIntl.of(context).settings_title),
                   leading: _buildDiscoveryFeatureDescriptionWidget(
                       context,
-                      (Theme.of(context).brightness == Brightness.dark &&
-                              isDiscoveryOverlayActive)
-                          ? const Icon(Icons.settings, color: Colors.black)
-                          : const Icon(Icons.settings),
+                      getProperIconAccordingToTheme(Icons.settings),
                       DiscoveryIds.detailsMoreSettings,
                       model),
                   onTap: () =>

--- a/lib/ui/views/more_view.dart
+++ b/lib/ui/views/more_view.dart
@@ -29,6 +29,7 @@ class MoreView extends StatefulWidget {
 }
 
 class _MoreViewState extends State<MoreView> {
+  bool isDiscoveryOverlayActive = false;
   @override
   void initState() {
     super.initState();
@@ -95,7 +96,10 @@ class _MoreViewState extends State<MoreView> {
                   title: Text(AppIntl.of(context).more_report_bug),
                   leading: _buildDiscoveryFeatureDescriptionWidget(
                       context,
-                      const Icon(Icons.bug_report),
+                      (Theme.of(context).brightness == Brightness.dark &&
+                              isDiscoveryOverlayActive)
+                          ? const Icon(Icons.bug_report, color: Colors.black)
+                          : const Icon(Icons.bug_report),
                       DiscoveryIds.detailsMoreBugReport,
                       model),
                   onTap: () => BetterFeedback.of(context).show((
@@ -111,7 +115,11 @@ class _MoreViewState extends State<MoreView> {
                   title: Text(AppIntl.of(context).more_contributors),
                   leading: _buildDiscoveryFeatureDescriptionWidget(
                       context,
-                      const Icon(Icons.people_outline),
+                      (Theme.of(context).brightness == Brightness.dark &&
+                              isDiscoveryOverlayActive)
+                          ? const Icon(Icons.people_outline,
+                              color: Colors.black)
+                          : const Icon(Icons.people_outline),
                       DiscoveryIds.detailsMoreContributors,
                       model),
                   onTap: () => model.navigationService
@@ -145,7 +153,10 @@ class _MoreViewState extends State<MoreView> {
                   title: Text(AppIntl.of(context).settings_title),
                   leading: _buildDiscoveryFeatureDescriptionWidget(
                       context,
-                      const Icon(Icons.settings),
+                      (Theme.of(context).brightness == Brightness.dark &&
+                              isDiscoveryOverlayActive)
+                          ? const Icon(Icons.settings, color: Colors.black)
+                          : const Icon(Icons.settings),
                       DiscoveryIds.detailsMoreSettings,
                       model),
                   onTap: () =>
@@ -200,6 +211,17 @@ class _MoreViewState extends State<MoreView> {
         tapTarget: icon,
         pulseDuration: const Duration(seconds: 5),
         child: icon,
-        onComplete: () => model.discoveryCompleted());
+        onComplete: () {
+          setState(() {
+            isDiscoveryOverlayActive = false;
+          });
+          return model.discoveryCompleted();
+        },
+        onOpen: () async {
+          setState(() {
+            isDiscoveryOverlayActive = true;
+          });
+          return true;
+        });
   }
 }

--- a/lib/ui/views/student_view.dart
+++ b/lib/ui/views/student_view.dart
@@ -81,7 +81,12 @@ class _StudentViewState extends State<StudentView> {
       description: discovery.details,
       backgroundColor: AppTheme.appletsDarkPurple,
       tapTarget: Tab(
-        text: tabs[index],
+        child: Text(
+          tabs[index],
+          style: (Theme.of(context).brightness == Brightness.dark)
+              ? const TextStyle(color: Colors.black)
+              : null,
+        ),
       ),
       pulseDuration: const Duration(seconds: 5),
       child: Tab(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ description: The 4th generation of ÉTSMobile, the main gateway between the Éco
 # pub.dev using `pub publish`. This is preferred for private packages.
 publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 
-version: 4.6.3+1
+version: 4.6.5+1
 
 environment:
   sdk: ">=2.10.0 <3.0.0"


### PR DESCRIPTION
Pour le texte de la section "Profil", j'ai rajouté une condition pour checker si le dark_theme est enabled et inverser la couleur du texte (uniquement pendant la discovery) en conséquence. 

![image](https://user-images.githubusercontent.com/69150827/150659711-8b493e18-65bf-4ffa-83cd-83cb34e4892c.png)

Pour les logos sur la page "Plus", j'ai ajouté un booléen qui via un setState, change d'état lorsque l'on rentre et que l'on sort de la discovery de l'item en particulier, ce qui permet de conserver la bonne couleur d'icône en temps normal.

![image](https://user-images.githubusercontent.com/69150827/150659753-a8c7e7b0-e1e6-45b0-84a1-290ed9842565.png)

Et hop', tout fonctionne comme il faut ! 

closes #171  
 