### PR TITLE
Fix auth

### DIFF
--- a/lib/core/constants/urls.dart
+++ b/lib/core/constants/urls.dart
@@ -12,6 +12,8 @@ class Urls {
 
   // SOAP Operations supported by the Signets API
   static const String signetsOperationBase = "http://etsmtl.ca/";
+  static const String donneesAuthentificationValides =
+      "donneesAuthentificationValides";
   static const String infoStudentOperation = "infoEtudiant";
   static const String listProgramsOperation = "listeProgrammes";
   static const String listClassScheduleOperation = "lireHoraireDesSeances";

--- a/lib/core/managers/user_repository.dart
+++ b/lib/core/managers/user_repository.dart
@@ -94,6 +94,8 @@ class UserRepository {
             _monETSUser = MonETSUser(
                 domain: "student", typeUsagerId: 1, username: username);
           } else {
+            _analyticsService.logError(
+                tag, "Authenticate - ${e.toString()}", e, stacktrace);
             return false;
           }
         } on Exception catch (e, stacktrace) {

--- a/lib/core/managers/user_repository.dart
+++ b/lib/core/managers/user_repository.dart
@@ -92,7 +92,9 @@ class UserRepository {
           if (await _signetsApi.authenticate(
               username: username, password: password)) {
             _monETSUser = MonETSUser(
-                domain: "student", typeUsagerId: 1, username: username);
+                domain: MonETSUser.mainDomain,
+                typeUsagerId: MonETSUser.studentRoleId,
+                username: username);
           } else {
             _analyticsService.logError(
                 tag, "Authenticate - ${e.toString()}", e, stacktrace);

--- a/lib/core/managers/user_repository.dart
+++ b/lib/core/managers/user_repository.dart
@@ -87,8 +87,6 @@ class UserRepository {
       // Try login in from signets if monETS failed
       if (e is HttpException) {
         try {
-          _analyticsService.logError(
-              tag, "Authenticate - ${e.toString()}", e, stacktrace);
           if (await _signetsApi.authenticate(
               username: username, password: password)) {
             _monETSUser = MonETSUser(

--- a/lib/core/models/mon_ets_user.dart
+++ b/lib/core/models/mon_ets_user.dart
@@ -3,6 +3,9 @@ import 'package:flutter/material.dart';
 
 /// User received from MonETS after a authentication
 class MonETSUser {
+  static const int studentRoleId = 1;
+  static const String mainDomain = "ENS";
+
   final String domain;
 
   final int typeUsagerId;

--- a/lib/core/services/signets_api.dart
+++ b/lib/core/services/signets_api.dart
@@ -42,6 +42,19 @@ class SignetsApi {
     }
   }
 
+  Future<bool> authenticate(
+      {@required String username, @required String password}) async {
+    // Generate initial soap envelope
+    final body = buildBasicSOAPBody(
+            Urls.donneesAuthentificationValides, username, password)
+        .buildDocument();
+    final responseBody =
+        await _sendSOAPRequest(body, Urls.donneesAuthentificationValides);
+
+    /// Build and return the authentication status
+    return responseBody.innerText == "true";
+  }
+
   /// Call the SignetsAPI to get the courses activities for the [session] for
   /// the student ([username]). By specifying [courseGroup] we can filter the
   /// results to get only the activities for this course.
@@ -340,11 +353,12 @@ class SignetsApi {
         .first;
 
     // Throw exception if the error tag contains a blocking error
-    if (responseBody
-        .findElements(_signetsErrorTag)
-        .first
-        .innerText
-        .isNotEmpty) {
+    if (responseBody.findElements(_signetsErrorTag).isNotEmpty &&
+        responseBody
+            .findElements(_signetsErrorTag)
+            .first
+            .innerText
+            .isNotEmpty) {
       switch (responseBody.findElements(_signetsErrorTag).first.innerText) {
         case SignetsError.scheduleNotAvailable:
         case SignetsError.scheduleNotAvailableF:

--- a/lib/core/utils/http_exceptions.dart
+++ b/lib/core/utils/http_exceptions.dart
@@ -13,6 +13,10 @@ class HttpException implements Exception {
         _code = code,
         _prefix = prefix;
 
+  int get code {
+    return _code;
+  }
+
   @override
   String toString() {
     return "$_prefix - $_code $_message";

--- a/lib/core/viewmodels/more_viewmodel.dart
+++ b/lib/core/viewmodels/more_viewmodel.dart
@@ -2,7 +2,6 @@
 import 'dart:io';
 import 'dart:typed_data';
 import 'package:feature_discovery/feature_discovery.dart';
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:fluttertoast/fluttertoast.dart';
 import 'package:package_info_plus/package_info_plus.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ description: The 4th generation of ÉTSMobile, the main gateway between the Éco
 # pub.dev using `pub publish`. This is preferred for private packages.
 publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 
-version: 4.6.7+1
+version: 4.7.0+1
 
 environment:
   sdk: ">=2.10.0 <3.0.0"

--- a/test/managers/user_repository_test.dart
+++ b/test/managers/user_repository_test.dart
@@ -50,6 +50,7 @@ void main() {
       setupLogger();
 
       manager = UserRepository();
+      SignetsApiMock.stubAuthenticate(signetsApi as SignetsApiMock);
     });
 
     tearDown(() {

--- a/test/managers/user_repository_test.dart
+++ b/test/managers/user_repository_test.dart
@@ -17,6 +17,7 @@ import 'package:notredame/core/models/mon_ets_user.dart';
 import 'package:notredame/core/models/profile_student.dart';
 import 'package:notredame/core/models/program.dart';
 import 'package:notredame/core/utils/api_exception.dart';
+import 'package:notredame/core/utils/http_exceptions.dart';
 
 // HELPERS
 import '../helpers.dart';
@@ -118,6 +119,70 @@ void main() {
       });
     });
 
+    group('authentication Signets - ', () {
+      test('right credentials but bad MonETS API', () async {
+        final MonETSUser user =
+            MonETSUser(domain: "ENS", typeUsagerId: 1, username: "AAXXXXXX");
+
+        MonETSApiMock.stubException(monETSApi as MonETSApiMock, user.username,
+            exception: HttpException(
+                prefix: "MonETSAPI",
+                code: 415,
+                message:
+                    "{ \"Message\": \"The request contains an entity body but no Content-Type header. The inferred media type 'application/octet-stream' is not supported for this resource.\"}"));
+        SignetsApiMock.stubAuthenticate(signetsApi as SignetsApiMock,
+            connected: true);
+
+        // Result is true
+        expect(
+            await manager.authenticate(username: user.username, password: ""),
+            isTrue,
+            reason: "Check the authentication is successful");
+
+        // Verify the secureStorage is used
+        verify(secureStorage.write(
+            key: UserRepository.usernameSecureKey, value: user.username));
+        verify(secureStorage.write(
+            key: UserRepository.passwordSecureKey, value: ""));
+
+        // Verify the user id is set in the analytics
+        verify(analyticsService.setUserProperties(
+            userId: user.username, domain: user.domain));
+      });
+
+      test('MonETSAPI failed and SignetsAPI return false', () async {
+        const String username = "exceptionUser";
+
+        MonETSApiMock.stubException(monETSApi as MonETSApiMock, username,
+            exception: HttpException(
+                prefix: "MonETSAPI",
+                code: 415,
+                message:
+                    "{ \"Message\": \"The request contains an entity body but no Content-Type header. The inferred media type 'application/octet-stream' is not supported for this resource.\"}"));
+        SignetsApiMock.stubAuthenticate(signetsApi as SignetsApiMock);
+
+        expect(await manager.authenticate(username: username, password: ""),
+            isFalse,
+            reason: "The authentication failed so the result should be false");
+
+        // Verify the user id isn't set in the analytics
+        verify(analyticsService.logError(UserRepository.tag, any, any, any))
+            .called(1);
+
+        // Verify the secureStorage isn't used
+        verifyNever(secureStorage.write(
+            key: UserRepository.usernameSecureKey, value: username));
+        verifyNever(secureStorage.write(
+            key: UserRepository.passwordSecureKey, value: ""));
+
+        // Verify the user id is set in the analytics
+        verifyNever(analyticsService.setUserProperties(
+            userId: username, domain: anyNamed("domain")));
+
+        expect(manager.monETSUser, null,
+            reason: "Verify the user stored should be null");
+      });
+    });
     group('silentAuthenticate - ', () {
       test('credentials are saved so the authentication should be done',
           () async {

--- a/test/mock/services/mon_ets_api_mock.dart
+++ b/test/mock/services/mon_ets_api_mock.dart
@@ -32,6 +32,7 @@ class MonETSApiMock extends Mock implements MonETSApi {
   /// will be called with this [username]
   static void stubException(MonETSApiMock mock, String username,
       {Exception exception}) {
+    exception ??= Exception();
     when(mock.authenticate(username: username, password: anyNamed('password')))
         .thenThrow(exception);
   }

--- a/test/mock/services/mon_ets_api_mock.dart
+++ b/test/mock/services/mon_ets_api_mock.dart
@@ -30,8 +30,9 @@ class MonETSApiMock extends Mock implements MonETSApi {
 
   /// Stub to throw an [Exception] when the authenticate
   /// will be called with this [username]
-  static void stubException(MonETSApiMock mock, String username) {
+  static void stubException(MonETSApiMock mock, String username,
+      {Exception exception}) {
     when(mock.authenticate(username: username, password: anyNamed('password')))
-        .thenThrow(Exception());
+        .thenThrow(exception);
   }
 }

--- a/test/mock/services/signets_api_mock.dart
+++ b/test/mock/services/signets_api_mock.dart
@@ -24,6 +24,13 @@ class SignetsApiMock extends Mock implements SignetsApi {
   static const courseRepositoryException =
       ApiException(prefix: CourseRepository.tag, message: "");
 
+  /// Stub the answer of the [authenticate].
+  static void stubAuthenticate(SignetsApiMock mock, {bool connected = false}) {
+    when(mock.authenticate(
+            username: anyNamed("username"), password: anyNamed("password")))
+        .thenAnswer((_) async => connected);
+  }
+
   /// Stub the answer of the [getCoursesActivities] when the [session] is used.
   static void stubGetCoursesActivities(SignetsApiMock mock, String session,
       List<CourseActivity> coursesActivitiesToReturn) {


### PR DESCRIPTION
Fix auth by bypassing the authentication from monETS portal if an error is thrown. If one is found, instead try to connect using the deprecated connexion API from Signets.  