### PR TITLE
Add feedback on today button press when today already selected

### DIFF
--- a/l10n/intl_en.arb
+++ b/l10n/intl_en.arb
@@ -69,6 +69,7 @@
   "schedule_settings_starting_weekday_sunday": "Sunday",
   "schedule_error_no_event_found": "No event found",
   "schedule_select_course_activity": "Select the group of the labo",
+  "schedule_already_today_toast": "Already showing today's schedule",
   "course_activity_group_a": "Group A",
   "course_activity_group_b": "Group B",
   "course_activity_group_both": "Both groups",

--- a/l10n/intl_fr.arb
+++ b/l10n/intl_fr.arb
@@ -67,6 +67,7 @@
   "schedule_settings_starting_weekday_sunday": "Dimanche",
   "schedule_no_event": "Aucun évènement à l'horaire.",
   "schedule_select_course_activity": "Sélectionner le groupe du laboratoire",
+  "schedule_already_today_toast": "Déjà sur l'horaire d'aujourd'hui",
   "course_activity_group_a": "Groupe A",
   "course_activity_group_b": "Groupe B",
   "course_activity_group_both": "Les deux groupes",

--- a/lib/core/viewmodels/schedule_viewmodel.dart
+++ b/lib/core/viewmodels/schedule_viewmodel.dart
@@ -269,6 +269,17 @@ class ScheduleViewModel extends FutureViewModel<List<CourseActivity>> {
     }
   }
 
+  /// Set current selected date to today (used by the today button in the view).
+  /// Show a toaster instead if the selected date is already today.
+  void selectToday() {
+    if (DateTime.now().day == selectedDate.day) {
+      Fluttertoast.showToast(msg: _appIntl.schedule_already_today_toast);
+    } else {
+      selectedDate = DateTime.now();
+      focusedDate.value = DateTime.now();
+    }
+  }
+
   /// Start Discovery if needed.
   static Future<void> startDiscovery(BuildContext context) async {
     final SettingsManager _settingsManager = locator<SettingsManager>();

--- a/lib/core/viewmodels/schedule_viewmodel.dart
+++ b/lib/core/viewmodels/schedule_viewmodel.dart
@@ -271,12 +271,18 @@ class ScheduleViewModel extends FutureViewModel<List<CourseActivity>> {
 
   /// Set current selected date to today (used by the today button in the view).
   /// Show a toaster instead if the selected date is already today.
-  void selectToday() {
+  ///
+  /// Return true if switched selected date to today (= today was not selected),
+  /// return false otherwise (today was already selected, show toast for
+  /// visual feedback).
+  bool selectToday() {
     if (DateTime.now().day == selectedDate.day) {
       Fluttertoast.showToast(msg: _appIntl.schedule_already_today_toast);
+      return false;
     } else {
       selectedDate = DateTime.now();
       focusedDate.value = DateTime.now();
+      return true;
     }
   }
 

--- a/lib/ui/views/schedule_view.dart
+++ b/lib/ui/views/schedule_view.dart
@@ -252,8 +252,8 @@ class _ScheduleViewState extends State<ScheduleView>
           IconButton(
               icon: const Icon(Icons.today),
               onPressed: () => setState(() {
-                model.selectToday();
-              })),
+                    model.selectToday();
+                  })),
         _buildDiscoveryFeatureDescriptionWidget(context, Icons.settings, model),
       ];
 

--- a/lib/ui/views/schedule_view.dart
+++ b/lib/ui/views/schedule_view.dart
@@ -2,6 +2,7 @@
 import 'package:feature_discovery/feature_discovery.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
+import 'package:fluttertoast/fluttertoast.dart';
 import 'package:intl/intl.dart';
 import 'package:stacked/stacked.dart';
 import 'package:table_calendar/table_calendar.dart';
@@ -252,9 +253,8 @@ class _ScheduleViewState extends State<ScheduleView>
           IconButton(
               icon: const Icon(Icons.today),
               onPressed: () => setState(() {
-                    model.selectedDate = DateTime.now();
-                    model.focusedDate.value = DateTime.now();
-                  })),
+                model.selectToday();
+              })),
         _buildDiscoveryFeatureDescriptionWidget(context, Icons.settings, model),
       ];
 

--- a/lib/ui/views/schedule_view.dart
+++ b/lib/ui/views/schedule_view.dart
@@ -2,7 +2,6 @@
 import 'package:feature_discovery/feature_discovery.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
-import 'package:fluttertoast/fluttertoast.dart';
 import 'package:intl/intl.dart';
 import 'package:stacked/stacked.dart';
 import 'package:table_calendar/table_calendar.dart';

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -98,7 +98,7 @@ packages:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.15.0"
+    version: "1.16.0"
   connectivity_plus:
     dependency: "direct main"
     description:
@@ -233,7 +233,7 @@ packages:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.0"
   feature_discovery:
     dependency: "direct main"
     description:
@@ -561,7 +561,7 @@ packages:
       name: js
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.6.3"
+    version: "0.6.4"
   json_annotation:
     dependency: transitive
     description:
@@ -603,7 +603,7 @@ packages:
       name: material_color_utilities
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.3"
+    version: "0.1.4"
   meta:
     dependency: transitive
     description:
@@ -687,7 +687,7 @@ packages:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.1"
   path_drawing:
     dependency: transitive
     description:
@@ -902,7 +902,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.1"
+    version: "1.8.2"
   sqflite:
     dependency: transitive
     description:
@@ -979,7 +979,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.8"
+    version: "0.4.9"
   typed_data:
     dependency: transitive
     description:
@@ -1063,7 +1063,7 @@ packages:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
   version:
     dependency: transitive
     description:
@@ -1135,5 +1135,5 @@ packages:
     source: hosted
     version: "3.1.0"
 sdks:
-  dart: ">=2.16.0 <3.0.0"
+  dart: ">=2.17.0-0 <3.0.0"
   flutter: ">=2.10.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ description: The 4th generation of ÉTSMobile, the main gateway between the Éco
 # pub.dev using `pub publish`. This is preferred for private packages.
 publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 
-version: 4.10.1+1
+version: 4.10.2+1
 
 environment:
   sdk: ">=2.10.0 <3.0.0"

--- a/test/viewmodels/schedule_viewmodel_test.dart
+++ b/test/viewmodels/schedule_viewmodel_test.dart
@@ -1,10 +1,8 @@
 // FLUTTER / DART / THIRD-PARTIES
 import 'package:flutter_test/flutter_test.dart';
-import 'package:fluttertoast/fluttertoast.dart';
 import 'package:intl/intl.dart';
 import 'package:mockito/mockito.dart';
 import 'package:table_calendar/table_calendar.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 // MANAGERS
 import 'package:notredame/core/managers/course_repository.dart';
@@ -796,11 +794,9 @@ void main() {
     });
 
     group('dateSelection -', () {
-      AppIntl intl;
 
       setUp(() async {
         setupFlutterToastMock();
-        intl = await setupAppIntl();
       });
 
       test('go back to todays schedule', () async {

--- a/test/viewmodels/schedule_viewmodel_test.dart
+++ b/test/viewmodels/schedule_viewmodel_test.dart
@@ -794,7 +794,6 @@ void main() {
     });
 
     group('dateSelection -', () {
-
       setUp(() async {
         setupFlutterToastMock();
       });

--- a/test/viewmodels/schedule_viewmodel_test.dart
+++ b/test/viewmodels/schedule_viewmodel_test.dart
@@ -810,24 +810,22 @@ void main() {
         viewModel.selectedDate = oldSelectedDate;
         viewModel.focusedDate.value = oldSelectedDate;
 
-        viewModel.selectToday();
+        final res = viewModel.selectToday();
 
         expect(viewModel.selectedDate.day, currentDate.day);
         expect(viewModel.focusedDate.value.day, currentDate.day);
-        verifyNever(Fluttertoast.showToast(msg: intl.schedule_already_today_toast));
+        expect(res, true, reason: "Today was not selected before");
       });
 
-      test('show toaster if already today selected', () async {
+      test('show toast if today already selected', () async {
         final today = DateTime.now();
 
         viewModel.selectedDate = today;
         viewModel.focusedDate.value = today;
 
-        viewModel.selectToday();
+        final res = viewModel.selectToday();
 
-        expect(viewModel.selectedDate.day, today.day);
-        expect(viewModel.focusedDate.value.day, today.day);
-        verify(Fluttertoast.showToast(msg: intl.schedule_already_today_toast)).called(1);
+        expect(res, false, reason: "Today is already selected");
       });
     });
   });

--- a/test/viewmodels/schedule_viewmodel_test.dart
+++ b/test/viewmodels/schedule_viewmodel_test.dart
@@ -1,8 +1,10 @@
 // FLUTTER / DART / THIRD-PARTIES
 import 'package:flutter_test/flutter_test.dart';
+import 'package:fluttertoast/fluttertoast.dart';
 import 'package:intl/intl.dart';
 import 'package:mockito/mockito.dart';
 import 'package:table_calendar/table_calendar.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 // MANAGERS
 import 'package:notredame/core/managers/course_repository.dart';
@@ -790,6 +792,42 @@ void main() {
         final activities = viewModel.coursesActivities;
 
         expect(activities.entries.toList()[0].value.length, 5);
+      });
+    });
+
+    group('dateSelection -', () {
+      AppIntl intl;
+
+      setUp(() async {
+        setupFlutterToastMock();
+        intl = await setupAppIntl();
+      });
+
+      test('go back to todays schedule', () async {
+        final oldSelectedDate = DateTime(2022, 1, 2);
+        final currentDate = DateTime.now();
+
+        viewModel.selectedDate = oldSelectedDate;
+        viewModel.focusedDate.value = oldSelectedDate;
+
+        viewModel.selectToday();
+
+        expect(viewModel.selectedDate.day, currentDate.day);
+        expect(viewModel.focusedDate.value.day, currentDate.day);
+        verifyNever(Fluttertoast.showToast(msg: intl.schedule_already_today_toast));
+      });
+
+      test('show toaster if already today selected', () async {
+        final today = DateTime.now();
+
+        viewModel.selectedDate = today;
+        viewModel.focusedDate.value = today;
+
+        viewModel.selectToday();
+
+        expect(viewModel.selectedDate.day, today.day);
+        expect(viewModel.focusedDate.value.day, today.day);
+        verify(Fluttertoast.showToast(msg: intl.schedule_already_today_toast)).called(1);
       });
     });
   });


### PR DESCRIPTION
Closes #393 

Add a toast as suggested in #393 when the user presses the "back to today" button in the schedule view and the currently selected date is already today (which is the default state of the view).
Previously no feedback would be given at all in that case, resulting in a lack of understanding of the purpose of this button.

What it looks like (French version):

<img src="https://user-images.githubusercontent.com/33004979/169098633-0f06108b-c1c4-48e7-ab52-effaf187e910.jpg" width="400">