### PR TITLE
Création d'un template pour les pull_request

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -1,0 +1,21 @@
+## 📖 Description
+<!--- Describe your changes in detail -->
+
+### 🧪 How Has This Been Tested?
+<!--- Please describe how you tested your changes. -->
+<!--- Include details of your unit test, and the manual tests you did -->
+<!--- see how your change affects other areas of the code, etc. -->
+
+### ⁉️ Related Issue
+<!--- If suggesting a new feature or change, please discuss it in an issue first -->
+<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
+<!--- Please link to the issue here: (use keyword `closes: #12345`) -->
+
+### ☑️ Checklist before requesting a review
+- [ ] I have performed a self-review of my code.
+- [ ] If it is a core feature, I have added thorough tests.
+- [ ] Do we need to implement analytics?
+- [ ] Did we updated the version in `pubspec.yaml`?
+
+### 🖼️ Screenshots (if useful):
+<!--- If it's a visual change, please provide a screenshot -->

--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -1,3 +1,8 @@
+### ⁉️ Related Issue
+<!--- If suggesting a new feature or change, please discuss it in an issue first -->
+<!--- For more explanation: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
+<!--- Please link the issue here: (use keyword `closes: #12345`) -->
+
 ## 📖 Description
 <!--- Describe your changes in detail -->
 
@@ -6,16 +11,11 @@
 <!--- Include details of your unit test, and the manual tests you did -->
 <!--- see how your change affects other areas of the code, etc. -->
 
-### ⁉️ Related Issue
-<!--- If suggesting a new feature or change, please discuss it in an issue first -->
-<!--- For more explanation: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
-<!--- Please link to the issue here: (use keyword `closes: #12345`) -->
-
 ### ☑️ Checklist before requesting a review
 - [ ] I have performed a self-review of my code.
 - [ ] If it is a core feature, I have added thorough tests.
 - [ ] Do we need to implement analytics?
-- [ ] Did we update the version in `pubspec.yaml`?
+- [ ] Make sure to add either one of the following labels: `version: Major`,`version: Minor` or `version: Patch`. 
 
 ### 🖼️ Screenshots (if useful):
 <!--- If it's a visual change, please provide a screenshot -->

--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -8,7 +8,7 @@
 
 ### ⁉️ Related Issue
 <!--- If suggesting a new feature or change, please discuss it in an issue first -->
-<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
+<!--- For more explanation: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
 <!--- Please link to the issue here: (use keyword `closes: #12345`) -->
 
 ### ☑️ Checklist before requesting a review

--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -15,7 +15,7 @@
 - [ ] I have performed a self-review of my code.
 - [ ] If it is a core feature, I have added thorough tests.
 - [ ] Do we need to implement analytics?
-- [ ] Did we updated the version in `pubspec.yaml`?
+- [ ] Did we update the version in `pubspec.yaml`?
 
 ### 🖼️ Screenshots (if useful):
 <!--- If it's a visual change, please provide a screenshot -->


### PR DESCRIPTION
Comme nous avons maintenant beaucoup de petits changements et beaucoup d'information à donner lors des première PR, j'ai pensé standardiser le template de PR pour aider le mieux possible les membres dans leur création de PR. Dedans, il y a une checklist que chaque contributeur pourra utiliser pour s'assurer que tout est en ordre avant de soumettre leur feature ou bugfix.

Vous pouvez me donner votre avis s'il manque des trucs! 😄