### PR TITLE
Fix firebase analytics runtime error

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -289,7 +289,7 @@ packages:
       name: firebase_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.18.0"
+    version: "1.19.2"
   firebase_core_platform_interface:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ description: The 4th generation of ÉTSMobile, the main gateway between the Éco
 # pub.dev using `pub publish`. This is preferred for private packages.
 publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 
-version: 4.12.4+1
+version: 4.12.5+1
 
 environment:
   sdk: ">=2.10.0 <3.0.0"


### PR DESCRIPTION
This PR is a small fix for the issue that appeared recently due to some incompatibilities introduced by dependabot updates.
The current state of the main branch is affected by this error, causing the app to remain stuck in the launching state.

Thanks @AntoineLemelin for finding the fix! 🔥 

<details>
<summary>Details of the error</summary>

```
E/flutter (21288): [ERROR:flutter/lib/ui/ui_dart_state.cc(198)] Unhandled Exception: PlatformException(channel-error, Unable to establish connection on channel., null, null)
E/flutter (21288): #0      FirebaseCoreHostApi.initializeCore (package:firebase_core_platform_interface/src/pigeon/messages.pigeon.dart:205:7)
E/flutter (21288): <asynchronous suspension>
E/flutter (21288): #1      MethodChannelFirebase._initializeCore (package:firebase_core_platform_interface/src/method_channel/method_channel_firebase.dart:29:44)
E/flutter (21288): <asynchronous suspension>
E/flutter (21288): #2      MethodChannelFirebase.initializeApp (package:firebase_core_platform_interface/src/method_channel/method_channel_firebase.dart:73:7)
E/flutter (21288): <asynchronous suspension>
E/flutter (21288): #3      Firebase.initializeApp (package:firebase_core/src/firebase.dart:40:31)
E/flutter (21288): <asynchronous suspension>
E/flutter (21288): #4      main (package:notredame/main.dart:38:3)
E/flutter (21288): <asynchronous suspension>
```
</details>