### PR TITLE
BugFix #663 Prevent the submit button from sending github issues mult…

### DIFF
--- a/lib/core/viewmodels/feedback_viewmodel.dart
+++ b/lib/core/viewmodels/feedback_viewmodel.dart
@@ -1,5 +1,6 @@
 // FLUTTER / DART / THIRD-PARTIES
 import 'dart:io';
+import 'dart:typed_data';
 import 'package:feedback/feedback.dart';
 import 'package:flutter/material.dart';
 import 'package:fluttertoast/fluttertoast.dart';

--- a/lib/core/viewmodels/feedback_viewmodel.dart
+++ b/lib/core/viewmodels/feedback_viewmodel.dart
@@ -20,14 +20,15 @@ class FeedbackViewModel extends BaseViewModel {
 
   final AppIntl _appIntl;
 
+  final int _screenshotImageWidth = 307;
+
   FeedbackViewModel({@required AppIntl intl}) : _appIntl = intl;
 
-  /// Create a Github issue with [feedbackText] and the screenshot associated.
+  /// Create a Github issue with [UserFeedback] and the screenshot associated.
   Future<void> sendFeedback(UserFeedback feedback) async {
     //Generate info to pass to github
     final File file = await _githubApi.localFile;
-    await file.writeAsBytes(image.encodePng(
-        image.copyResize(image.decodeImage(feedback.screenshot), width: 307)));
+    await file.writeAsBytes(encodeScreenshotForGithub(feedback.screenshot));
 
     final String fileName = file.path.split('/').last;
 
@@ -37,16 +38,22 @@ class FeedbackViewModel extends BaseViewModel {
     _githubApi.createGithubIssue(
         feedbackText: feedback.text,
         fileName: fileName,
-        feedbackType: getUserFeedBackType(feedback));
+        feedbackType: getUserFeedbackType(feedback));
 
     file.deleteSync();
+
     Fluttertoast.showToast(
       msg: _appIntl.thank_you_for_the_feedback,
       gravity: ToastGravity.CENTER,
     );
   }
 
-  String getUserFeedBackType(UserFeedback userFeedback) {
+  List<int> encodeScreenshotForGithub(Uint8List screenshot) {
+    return image.encodePng(image.copyResize(image.decodeImage(screenshot),
+        width: _screenshotImageWidth));
+  }
+
+  String getUserFeedbackType(UserFeedback userFeedback) {
     return userFeedback.extra.entries.first.value.toString().split('.').last;
   }
 }

--- a/lib/core/viewmodels/feedback_viewmodel.dart
+++ b/lib/core/viewmodels/feedback_viewmodel.dart
@@ -1,6 +1,6 @@
 // FLUTTER / DART / THIRD-PARTIES
 import 'dart:io';
-import 'dart:typed_data';
+import 'package:feedback/feedback.dart';
 import 'package:flutter/material.dart';
 import 'package:fluttertoast/fluttertoast.dart';
 import 'package:stacked/stacked.dart';
@@ -22,12 +22,11 @@ class FeedbackViewModel extends BaseViewModel {
   FeedbackViewModel({@required AppIntl intl}) : _appIntl = intl;
 
   /// Create a Github issue with [feedbackText] and the screenshot associated.
-  Future<void> sendFeedback(String feedbackText, Uint8List feedbackScreenshot,
-      String feedbackType) async {
+  Future<void> sendFeedback(UserFeedback feedback) async {
     //Generate info to pass to github
     final File file = await _githubApi.localFile;
     await file.writeAsBytes(image.encodePng(
-        image.copyResize(image.decodeImage(feedbackScreenshot), width: 307)));
+        image.copyResize(image.decodeImage(feedback.screenshot), width: 307)));
 
     final String fileName = file.path.split('/').last;
 
@@ -35,14 +34,18 @@ class FeedbackViewModel extends BaseViewModel {
     _githubApi.uploadFileToGithub(filePath: fileName, file: file);
 
     _githubApi.createGithubIssue(
-        feedbackText: feedbackText,
+        feedbackText: feedback.text,
         fileName: fileName,
-        feedbackType: feedbackType);
+        feedbackType: getUserFeedBackType(feedback));
 
     file.deleteSync();
     Fluttertoast.showToast(
       msg: _appIntl.thank_you_for_the_feedback,
       gravity: ToastGravity.CENTER,
     );
+  }
+
+  String getUserFeedBackType(UserFeedback userFeedback) {
+    return userFeedback.extra.entries.first.value.toString().split('.').last;
   }
 }

--- a/lib/ui/views/feedback_view.dart
+++ b/lib/ui/views/feedback_view.dart
@@ -8,6 +8,8 @@ import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:notredame/core/viewmodels/feedback_viewmodel.dart';
 
 class FeedbackView extends StatelessWidget {
+  bool _hasSubmited = false;
+
   @override
   Widget build(BuildContext context) =>
       ViewModelBuilder<FeedbackViewModel>.reactive(
@@ -50,15 +52,20 @@ class FeedbackView extends StatelessWidget {
                 FloatingActionButtonLocation.centerFloat,
             floatingActionButton: FloatingActionButton.extended(
               onPressed: () => BetterFeedback.of(context).show((feedback) {
-                model
-                    .sendFeedback(
-                        feedback.text,
-                        feedback.screenshot,
-                        feedback.extra.entries.first.value
-                            .toString()
-                            .split('.')
-                            .last)
-                    .then((value) => BetterFeedback.of(context).hide());
+                _hasSubmited
+                    ? null
+                    : {
+                        _hasSubmited = true,
+                        model
+                            .sendFeedback(
+                                feedback.text,
+                                feedback.screenshot,
+                                feedback.extra.entries.first.value
+                                    .toString()
+                                    .split('.')
+                                    .last)
+                            .then((value) => BetterFeedback.of(context).hide()),
+                      };
               }),
               label: Text(AppIntl.of(context).more_report_bug_button),
             ),

--- a/lib/ui/views/feedback_view.dart
+++ b/lib/ui/views/feedback_view.dart
@@ -51,14 +51,12 @@ class FeedbackView extends StatelessWidget {
                 FloatingActionButtonLocation.centerFloat,
             floatingActionButton: FloatingActionButton.extended(
               onPressed: () => BetterFeedback.of(context).show((feedback) {
-                _hasSubmitted
-                    ? null
-                    : {
-                        _hasSubmitted = true,
-                        model
-                            .sendFeedback(feedback)
-                            .then((value) => BetterFeedback.of(context).hide())
-                      };
+                if (!_hasSubmitted) {
+                  _hasSubmitted = true;
+                  model
+                      .sendFeedback(feedback)
+                      .then((value) => BetterFeedback.of(context).hide());
+                }
               }),
               label: Text(AppIntl.of(context).more_report_bug_button),
             ),

--- a/lib/ui/views/feedback_view.dart
+++ b/lib/ui/views/feedback_view.dart
@@ -13,7 +13,7 @@ class FeedbackView extends StatelessWidget {
       ViewModelBuilder<FeedbackViewModel>.reactive(
         viewModelBuilder: () => FeedbackViewModel(intl: AppIntl.of(context)),
         builder: (context, model, child) {
-          bool _hasSubmitted = false;
+          bool _hasSubmittedFeedback = false;
           return Scaffold(
             appBar: AppBar(
               title: Text(AppIntl.of(context).more_report_bug),
@@ -50,14 +50,17 @@ class FeedbackView extends StatelessWidget {
             floatingActionButtonLocation:
                 FloatingActionButtonLocation.centerFloat,
             floatingActionButton: FloatingActionButton.extended(
-              onPressed: () => BetterFeedback.of(context).show((feedback) {
-                if (!_hasSubmitted) {
-                  _hasSubmitted = true;
-                  model
-                      .sendFeedback(feedback)
-                      .then((value) => BetterFeedback.of(context).hide());
-                }
-              }),
+              onPressed: () => {
+                BetterFeedback.of(context).show((feedback) {
+                  if (!_hasSubmittedFeedback) {
+                    _hasSubmittedFeedback = true;
+                    model
+                        .sendFeedback(feedback)
+                        .then((value) => BetterFeedback.of(context).hide());
+                  }
+                }),
+                _hasSubmittedFeedback = false
+              },
               label: Text(AppIntl.of(context).more_report_bug_button),
             ),
           );

--- a/lib/ui/views/feedback_view.dart
+++ b/lib/ui/views/feedback_view.dart
@@ -8,13 +8,12 @@ import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:notredame/core/viewmodels/feedback_viewmodel.dart';
 
 class FeedbackView extends StatelessWidget {
-  bool _hasSubmited = false;
-
   @override
   Widget build(BuildContext context) =>
       ViewModelBuilder<FeedbackViewModel>.reactive(
         viewModelBuilder: () => FeedbackViewModel(intl: AppIntl.of(context)),
         builder: (context, model, child) {
+          bool _hasSubmitted = false;
           return Scaffold(
             appBar: AppBar(
               title: Text(AppIntl.of(context).more_report_bug),
@@ -52,19 +51,13 @@ class FeedbackView extends StatelessWidget {
                 FloatingActionButtonLocation.centerFloat,
             floatingActionButton: FloatingActionButton.extended(
               onPressed: () => BetterFeedback.of(context).show((feedback) {
-                _hasSubmited
+                _hasSubmitted
                     ? null
                     : {
-                        _hasSubmited = true,
+                        _hasSubmitted = true,
                         model
-                            .sendFeedback(
-                                feedback.text,
-                                feedback.screenshot,
-                                feedback.extra.entries.first.value
-                                    .toString()
-                                    .split('.')
-                                    .last)
-                            .then((value) => BetterFeedback.of(context).hide()),
+                            .sendFeedback(feedback)
+                            .then((value) => BetterFeedback.of(context).hide())
                       };
               }),
               label: Text(AppIntl.of(context).more_report_bug_button),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ description: The 4th generation of ÉTSMobile, the main gateway between the Éco
 # pub.dev using `pub publish`. This is preferred for private packages.
 publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 
-version: 4.16.0+1
+version: 4.16.1+1
 
 environment:
   sdk: ">=2.10.0 <3.0.0"

--- a/test/viewmodels/feedback_viewmodel_test.dart
+++ b/test/viewmodels/feedback_viewmodel_test.dart
@@ -1,5 +1,7 @@
 // FLUTTER / DART / THIRD-PARTIES
 import 'dart:io';
+import 'dart:typed_data';
+import 'package:feedback/feedback.dart';
 import 'package:flutter/services.dart';
 import 'package:image/image.dart' as image;
 import 'package:flutter_test/flutter_test.dart';
@@ -25,6 +27,12 @@ void main() {
 
   AppIntl appIntl;
   FeedbackViewModel viewModel;
+  const String feedBackText = 'Notre-Dame bug report';
+  final Map<String, dynamic> extra = {'': 'bugReport'};
+
+  String getUserFeedBackType() {
+    return extra.entries.first.value.toString().split('.').last;
+  }
 
   group('FeedbackViewModel - ', () {
     setUp(() async {
@@ -58,8 +66,8 @@ void main() {
         await file.writeAsBytes(image.encodePng(
             image.copyResize(image.decodeImage(screenshotData), width: 307)));
 
-        await viewModel.sendFeedback(
-            'Notre-Dame bug report', screenshotData, 'bugReport');
+        await viewModel.sendFeedback(UserFeedback(
+            text: feedBackText, screenshot: screenshotData, extra: extra));
 
         verify(githubApiMock.uploadFileToGithub(
           filePath: file.path.split('/').last,
@@ -71,13 +79,13 @@ void main() {
         final File file = File('bugReportTest.png');
         GithubApiMock.stubLocalFile(githubApiMock, file);
 
-        await viewModel.sendFeedback(
-            'Notre-Dame bug report', screenshotData, 'bugReport');
+        await viewModel.sendFeedback(UserFeedback(
+            text: feedBackText, screenshot: screenshotData, extra: extra));
 
         verify(githubApiMock.createGithubIssue(
-            feedbackText: 'Notre-Dame bug report',
+            feedbackText: feedBackText,
             fileName: file.path.split('/').last,
-            feedbackType: 'bugReport'));
+            feedbackType: getUserFeedBackType()));
       });
     });
   });

--- a/test/viewmodels/feedback_viewmodel_test.dart
+++ b/test/viewmodels/feedback_viewmodel_test.dart
@@ -1,6 +1,5 @@
 // FLUTTER / DART / THIRD-PARTIES
 import 'dart:io';
-import 'dart:typed_data';
 import 'package:feedback/feedback.dart';
 import 'package:flutter/services.dart';
 import 'package:image/image.dart' as image;
@@ -32,7 +31,7 @@ void main() {
   final filePath = file.path.split('/').last;
   final Map<String, dynamic> extra = {'': 'bugReport'};
 
-  String getUserFeedBackType() {
+  String getUserFeedbackType() {
     return extra.entries.first.value.toString().split('.').last;
   }
 
@@ -85,7 +84,7 @@ void main() {
         verify(githubApiMock.createGithubIssue(
             feedbackText: feedBackText,
             fileName: filePath,
-            feedbackType: getUserFeedBackType()));
+            feedbackType: getUserFeedbackType()));
       });
     });
   });

--- a/test/viewmodels/feedback_viewmodel_test.dart
+++ b/test/viewmodels/feedback_viewmodel_test.dart
@@ -27,7 +27,9 @@ void main() {
 
   AppIntl appIntl;
   FeedbackViewModel viewModel;
-  const String feedBackText = 'Notre-Dame bug report';
+  const feedBackText = 'Notre-Dame bug report';
+  final file = File('bugReportTest.png');
+  final filePath = file.path.split('/').last;
   final Map<String, dynamic> extra = {'': 'bugReport'};
 
   String getUserFeedBackType() {
@@ -59,7 +61,6 @@ void main() {
       });
 
       test('If the file uploaded matches', () async {
-        final File file = File('bugReportTest.png');
         GithubApiMock.stubLocalFile(githubApiMock, file);
         setupFlutterToastMock();
 
@@ -70,13 +71,12 @@ void main() {
             text: feedBackText, screenshot: screenshotData, extra: extra));
 
         verify(githubApiMock.uploadFileToGithub(
-          filePath: file.path.split('/').last,
+          filePath: filePath,
           file: file,
         ));
       });
 
       test('If the github issue has been created', () async {
-        final File file = File('bugReportTest.png');
         GithubApiMock.stubLocalFile(githubApiMock, file);
 
         await viewModel.sendFeedback(UserFeedback(
@@ -84,7 +84,7 @@ void main() {
 
         verify(githubApiMock.createGithubIssue(
             feedbackText: feedBackText,
-            fileName: file.path.split('/').last,
+            fileName: filePath,
             feedbackType: getUserFeedBackType()));
       });
     });


### PR DESCRIPTION
…iple times when user clicks the button multiple times.

### ⁉️ Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- For more explanation: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--- Please link the issue here: (use keyword `closes: #663`) -->

## 📖 Description
I've added a boolean to capture the state of the code being executed that pushes the issue to github. Since the button submit itself is in the BetterFeedback package i couldn't modify code inside it. 

### 🧪 How Has This Been Tested?
I tested by printing out in the terminal command and testing if clicking the button multiple times only prints out once. 

### ☑️ Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.
- [x] Do we need to implement analytics?
- [x] Make sure to add either one of the following labels: `version: Major`,`version: Minor` or `version: Patch`. 

### 🖼️ Screenshots (if useful):
<!--- If it's a visual change, please provide a screenshot -->
