### PR TITLE
Fix Today button in schedule

### DIFF
--- a/lib/core/viewmodels/schedule_viewmodel.dart
+++ b/lib/core/viewmodels/schedule_viewmodel.dart
@@ -276,7 +276,7 @@ class ScheduleViewModel extends FutureViewModel<List<CourseActivity>> {
   /// return false otherwise (today was already selected, show toast for
   /// visual feedback).
   bool selectToday() {
-    if (DateTime.now().day == selectedDate.day) {
+    if (compareDates(selectedDate, DateTime.now())) {
       Fluttertoast.showToast(msg: _appIntl.schedule_already_today_toast);
       return false;
     } else {
@@ -284,6 +284,16 @@ class ScheduleViewModel extends FutureViewModel<List<CourseActivity>> {
       focusedDate.value = DateTime.now();
       return true;
     }
+  }
+
+  /// This function is used to compare two dates without taking
+  /// into account the time.
+  ///
+  /// Return true if the dates are the same, false otherwise.
+  bool compareDates(DateTime date1, DateTime date2) {
+    return date1.year == date2.year &&
+        date1.month == date2.month &&
+        date1.day == date2.day;
   }
 
   /// Start Discovery if needed.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ description: The 4th generation of ÉTSMobile, the main gateway between the Éco
 # pub.dev using `pub publish`. This is preferred for private packages.
 publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 
-version: 4.13.2+1
+version: 4.13.3+1
 
 environment:
   sdk: ">=2.10.0 <3.0.0"


### PR DESCRIPTION
### ⁉️ Related Issue
There was an issue with the Today button in the schedule, causing tests to not pass on every 2nd day of the month.

## 📖 Description
Changed the way dates are being compared to avoid the test from doing wrong assumptions.

### 🧪 How Has This Been Tested?
The tests that were not passing before are passing now.

### ☑️ Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.
- [x] Do we need to implement analytics?
- [x] Make sure to add either one of the following labels: `version: Major`,`version: Minor` or `version: Patch`. 

### 🖼️ Screenshots (if useful):
N/A
