### PR TITLE
BugFix #480 Prevent course acronyms to move when page is clicked / sc…

### DIFF
--- a/lib/ui/views/grade_details_view.dart
+++ b/lib/ui/views/grade_details_view.dart
@@ -33,7 +33,6 @@ class _GradesDetailsViewState extends State<GradesDetailsView>
     with TickerProviderStateMixin {
   AnimationController _controller;
   bool _completed = false;
-  double initialTopHeight = 0.0;
 
   @override
   void initState() {
@@ -69,41 +68,20 @@ class _GradesDetailsViewState extends State<GradesDetailsView>
                 headerSliverBuilder: (context, innerBoxScrolled) => [
                   SliverAppBar(
                     pinned: true,
-                    stretch: true,
-                    elevation: 0,
                     onStretchTrigger: () {
                       return Future<void>.value();
                     },
-                    expandedHeight: 80.0,
-                    flexibleSpace: LayoutBuilder(
-                      builder:
-                          (BuildContext context, BoxConstraints constraints) {
-                        if (initialTopHeight == 0.0) {
-                          initialTopHeight = constraints.biggest.height;
-                        }
-                        final double topHeight = constraints.biggest.height;
-
-                        return FlexibleSpaceBar(
-                          centerTitle: true,
-                          titlePadding: EdgeInsetsDirectional.only(
-                            start: topHeight < initialTopHeight ? 50.0 : 15.0,
-                            bottom: topHeight < initialTopHeight ? 16.0 : 5.0,
-                          ),
-                          title: Align(
-                            alignment: AlignmentDirectional.bottomStart,
-                            child: Text(
-                              model.course.acronym ?? "",
-                              style: Theme.of(context)
-                                  .textTheme
-                                  .bodyText1
-                                  .copyWith(
-                                      color: Colors.white,
-                                      fontSize: 19,
-                                      fontWeight: FontWeight.bold),
-                            ),
-                          ),
-                        );
-                      },
+                    titleSpacing: 0,
+                    leading: IconButton(
+                      icon: const Icon(Icons.arrow_back),
+                      onPressed: () => Navigator.of(context).pop(),
+                    ),
+                    title: Text(
+                      model.course.acronym ?? "",
+                      style: Theme.of(context).textTheme.bodyText1.copyWith(
+                          color: Colors.white,
+                          fontSize: 25,
+                          fontWeight: FontWeight.bold),
                     ),
                   ),
                   SliverToBoxAdapter(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ description: The 4th generation of ÉTSMobile, the main gateway between the Éco
 # pub.dev using `pub publish`. This is preferred for private packages.
 publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 
-version: 4.13.3+1
+version: 4.13.4+1
 
 environment:
   sdk: ">=2.10.0 <3.0.0"


### PR DESCRIPTION
…rolled for a more pleasurable ui experience.

### ⁉️ Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- For more explanation: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--- Please link the issue here: (use keyword `closes: #12345`) -->

## 📖 Description
<!--- Describe your changes in detail -->

### 🧪 How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
<!--- Include details of your unit test, and the manual tests you did -->
<!--- see how your change affects other areas of the code, etc. -->

### ☑️ Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.
- [x] Do we need to implement analytics?
- [x] Make sure to add either one of the following labels: `version: Major`,`version: Minor` or `version: Patch`. 

### 🖼️ Screenshots (if useful):
![Course Acronyms](https://user-images.githubusercontent.com/60085081/193661303-279f8998-293c-461a-bce0-b98d4d199f2b.gif)

