### PR TITLE
Add gitattributes to prevent githooks from reformatting all files on commit

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ description: The 4th generation of ÉTSMobile, the main gateway between the Éco
 # pub.dev using `pub publish`. This is preferred for private packages.
 publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 
-version: 4.13.4+1
+version: 4.13.5+1
 
 environment:
   sdk: ">=2.10.0 <3.0.0"


### PR DESCRIPTION
### ⁉️ Related Issue
Closes #679 

## 📖 Description
This small workaround should prevent Github Desktop (on Windows at least) from reformatting all files in the project with new EOL characters and adding them to commits.

### 🧪 How Has This Been Tested?
Tested on Github Desktop on Windows. Testing that this workaround does not break anything on macOS/Linux environments before merge is not done yet and would be greatly appreciated :)
**[EDIT] MacOS testing successful** (behavior remains unchanged after using the config suggested in this PR)

### ☑️ Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.
- [x] Do we need to implement analytics?
- [x] Make sure to add either one of the following labels: `version: Major`,`version: Minor` or `version: Patch`. 

### 🖼️ Screenshots (if useful):
Not useful here
