### PR TITLE
Fix text color on "retry" button

### DIFF
--- a/lib/ui/widgets/grade_not_available.dart
+++ b/lib/ui/widgets/grade_not_available.dart
@@ -39,9 +39,10 @@ class GradeNotAvailable extends StatelessWidget {
         ),
         const SizedBox(height: 25),
         ElevatedButton(
-            style: ButtonStyle(
-                backgroundColor:
-                    MaterialStateProperty.all(AppTheme.etsLightRed)),
+            style: ElevatedButton.styleFrom(
+                backgroundColor: AppTheme.etsLightRed,
+                foregroundColor: Colors.white
+            ),
             onPressed: onPressed,
             child: Text(AppIntl.of(context).retry))
       ],


### PR DESCRIPTION
### ⁉️ Related Issue
closes: #712 

## 📖 Description
Since the Material 3 support was released, the text in the "refresh" button had disappeared in the widget "grade_not_available".
After investigation, it was found that the text was now the same color as the button it was in, making it invisible.
Changing the style from "ButtonStyle(...)" to "ElevatedButton.styleFrom(...)" and specifying the text color made the text appear again.

### 🧪 How Has This Been Tested?
The change was tested manually.

### 🖼️ Screenshots (if useful):
For screenshot of before fix, see issue #712 
After fix :
<!--- If it's a visual change, please provide a screenshot -->
![image](https://user-images.githubusercontent.com/60433475/201541037-585a22aa-dc23-4fb1-a055-9cf611868fcf.png)
![image](https://user-images.githubusercontent.com/60433475/201546010-c6be6607-ed01-4db7-84ab-6dacf687224c.png)
