### PR TITLE
Fix build status badge in readme

### DIFF
--- a/README.fr.md
+++ b/README.fr.md
@@ -4,8 +4,8 @@
     <br /><strong>Projet Notre-Dame</strong>
     <br />
     <br />
-    <a href="https://github.com/ApplETS/Notre-Dame/actions/workflows/main-workflow.yaml" style="text-decoration: none;">
-      <img src="https://github.com/ApplETS/Notre-Dame/actions/workflows/main-workflow.yaml/badge.svg?branch=master" alt="Statut de la compilation"/>
+    <a href="https://github.com/ApplETS/Notre-Dame/actions/workflows/master-workflow.yaml" style="text-decoration: none;">
+      <img src="https://github.com/ApplETS/Notre-Dame/actions/workflows/master-workflow.yaml/badge.svg?branch=master" alt="Statut de la compilation"/>
     </a>
     <img src="https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/clubapplets-server/e51406de3b919a69f396642a2bcb413c/raw/notre_dame_master_badge_coverage.json" alt="Code coverage"/>
     <br />

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
     <br /><strong>Notre-Dame Project</strong>
     <br />
     <br />
-    <a href="https://github.com/ApplETS/Notre-Dame/actions/workflows/main-workflow.yaml" style="text-decoration: none;">
-        <img src="https://github.com/ApplETS/Notre-Dame/actions/workflows/main-workflow.yaml/badge.svg?branch=master" alt="Build Status"/>
+    <a href="https://github.com/ApplETS/Notre-Dame/actions/workflows/master-workflow.yaml" style="text-decoration: none;">
+        <img src="https://github.com/ApplETS/Notre-Dame/actions/workflows/master-workflow.yaml/badge.svg?branch=master" alt="Build Status"/>
     </a>
     <img src="https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/clubapplets-server/e51406de3b919a69f396642a2bcb413c/raw/notre_dame_master_badge_coverage.json" alt="Code coverage"/>
     <br />


### PR DESCRIPTION
### ⁉️ Related Issue
No related issue

## 📖 Description
With the #707 merge, the build status badge doesn't work.

### 🧪 How Has This Been Tested?
Both changed URL work.

### ☑️ Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] If needed, I added analytics.
- [x] Make sure to add either one of the following labels: `version: Major`,`version: Minor` or `version: Patch`. 
- [ ] Make sure golden files changes were reviewed and approved.

### 🖼️ Screenshots (if useful):
![image](https://user-images.githubusercontent.com/80051842/213890154-1fd4621e-5500-4208-aeb9-3d93ab7f722a.png)

