### PR TITLE
Remove testing racing condition in dev-workflow

### DIFF
--- a/.github/workflows/dev-workflow.yaml
+++ b/.github/workflows/dev-workflow.yaml
@@ -49,7 +49,7 @@ jobs:
             'This PR exceeds the recommended size of 1000 lines.
             Please make sure you are NOT addressing multiple issues with one PR.
             Note this PR might be rejected due to its size.’
-  bump-version:
+  bump_version:
     name: Bump app version using PR labels
     runs-on: ubuntu-latest
     env:
@@ -67,6 +67,8 @@ jobs:
   testing:
     name: Tests and checks
     runs-on: ubuntu-latest
+    needs:
+      - bump_version
     outputs:
       coverage: ${{ steps.coverage.outputs.percentage }}
     steps:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ description: The 4th generation of ÉTSMobile, the main gateway between the Éco
 # pub.dev using `pub publish`. This is preferred for private packages.
 publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 
-version: 4.19.0+1
+version: 4.19.1+1
 
 environment:
   sdk: ">=2.10.0 <3.0.0"


### PR DESCRIPTION
### ⁉️ Related Issue
During some builds, an error appears with the message

> error: failed to push some refs to 'https://github.com/ApplETS/Notre-Dame'
> hint: Updates were rejected because the tip of your current branch is behind
> hint: its remote counterpart. Integrate the remote changes (e.g.
> hint: 'git pull ...') before pushing again.
> hint: See the 'Note about fast-forwards' in 'git push --help' for details.

[Example](https://github.com/ApplETS/Notre-Dame/actions/runs/3981900332/jobs/6825936065#step:9:76)

## 📖 Description
I suspect the problem is a racing condition with the bump_version and testing steps in the dev-workflow. With these changes, the testing step will execute after the bump_version step. This will prevent the racing condition.

### 🧪 How Has This Been Tested?
The build from this PR is the test. The testing step executed after the bump_version.

### ☑️ Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] If needed, I added analytics.
- [x] Make sure to add either one of the following labels: `version: Major`,`version: Minor` or `version: Patch`. 
- [ ] Make sure golden files changes were reviewed and approved.

### 🖼️ Screenshots (if useful):
