### PR TITLE
Fix play store badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
     </a>
     <img src="https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/clubapplets-server/e51406de3b919a69f396642a2bcb413c/raw/notre_dame_master_badge_coverage.json" alt="Code coverage"/>
     <br />
-    <img src="https://img.shields.io/endpoint?color=green&logo=google-play&logoColor=green&url=https%3A%2F%2Fplayshields.herokuapp.com%2Fplay%3Fi%3Dca.etsmtl.applets.etsmobile%26l%3DPlay%2520Store%2520version%26m%3D%24version" alt="Play store version"/>
+    <img src="https://img.shields.io/endpoint?color=green&logo=google-play&logoColor=green&url=https%3A%2F%2Fplay.cuzi.workers.dev%2Fplay%3Fi%3Dca.etsmtl.applets.etsmobile%26l%3DPlay%2520Store%2520version%26m%3Dv%24version" alt="Play store version"/>
     <br />
     <img src="https://img.shields.io/itunes/v/557463461?label=App%20Store%20version&logo=appstore" alt="App store version"/>
     <br />


### PR DESCRIPTION
### ⁉️ Related Issue
No related issue (minor README fix)

## 📖 Description
Fixed the Play Store badge on the README.
I used [this tool](https://play.cuzi.workers.dev/) to generate the badge since the [old tool](https://github.com/cvzi/playshields) is no longer maintained.

### 🧪 How Has This Been Tested?
The badge appears correctly on WYSIWYG markdown editors (VS Code preview, Github preview), and the image URL can be opened in a web browser.

### ☑️ Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] If needed, I added analytics.
- [x] Make sure to add either one of the following labels: `version: Major`,`version: Minor` or `version: Patch`. 
- [ ] Make sure golden files changes were reviewed and approved.

### 🖼️ Screenshots (if useful):
VS Code preview:
![image](https://user-images.githubusercontent.com/33004979/215567608-0d7d7c10-a3b4-4356-bdfc-662a88738c7c.png)
