### PR TITLE
#807 Change Rubik link to HoraireÉTS

### DIFF
--- a/l10n/intl_en.arb
+++ b/l10n/intl_en.arb
@@ -163,7 +163,7 @@
   "ets_moodle_title": "Moodle",
   "ets_directory_title": "Directory",
   "ets_heuristique_title": "L'heuristique",
-  "ets_schedule_generator": "Rubik",
+  "ets_schedule_generator": "HoraireÉTS",
   "ets_gus": "GUS",
   "ets_papercut_title":"PaperCut",
 

--- a/l10n/intl_fr.arb
+++ b/l10n/intl_fr.arb
@@ -161,7 +161,7 @@
   "ets_moodle_title": "Moodle",
   "ets_directory_title": "Bottin",
   "ets_heuristique_title": "L'heuristique",
-  "ets_schedule_generator": "Rubik",
+  "ets_schedule_generator": "HoraireÉTS",
   "ets_gus": "GUS",
   "ets_papercut_title":"PaperCut",
 

--- a/lib/core/constants/quick_links.dart
+++ b/lib/core/constants/quick_links.dart
@@ -64,7 +64,7 @@ List<QuickLink> quickLinks(AppIntl intl) => [
             color: AppTheme.etsLightRed,
             size: 64,
           ),
-          link: 'http://rubik.clubnaova.ca/'),
+          link: 'https://horairets.emmanuelcoulombe.dev/'),
       QuickLink(
           name: intl.ets_gus,
           image: SvgPicture.asset('assets/images/ic_gus_red.svg',


### PR DESCRIPTION
### ⁉️ Related Issue
#807 Change Rubik link to HoraireÉTS

## 📖 Description
I changed the link and the i10n strings as mentioned in the previous pull request.

### 🧪 How Has This Been Tested?
I manually tested it by clicking on the link. The quick link redirects correctly to the given link but my emulator has not been able to load the page.

### ☑️ Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [n/a] If it is a core feature, I have added thorough tests.
- [n/a] If needed, I added analytics.
- [x] Make sure to add either one of the following labels: `version: Major`,`version: Minor` or `version: Patch`. 
- [n/a] Make sure golden files changes were reviewed and approved.

### 🖼️ Screenshots (if useful):
No screenshot needed
