### PR TITLE
Bump pubspec versions

### DIFF
--- a/.github/workflows/master-workflow.yaml
+++ b/.github/workflows/master-workflow.yaml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: Get the version from the pubspec
         id: pubspecVersion
-        uses: CumulusDS/get-yaml-paths-action@v1.0.1
+        uses: CumulusDS/get-yaml-paths-action@v1.0.2
         with:
           file: pubspec.yaml
           version: version

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -904,7 +904,7 @@ packages:
       name: pub_semver
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.4"
   rive:
     dependency: "direct main"
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -190,6 +190,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "3.0.1"
+  csslib:
+    dependency: transitive
+    description:
+      name: csslib
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.17.2"
   dart_style:
     dependency: transitive
     description:
@@ -562,13 +569,20 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.2"
+  google_maps:
+    dependency: transitive
+    description:
+      name: google_maps
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "6.3.0"
   google_maps_flutter:
     dependency: "direct main"
     description:
       name: google_maps_flutter
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.2.1"
+    version: "2.3.0"
   google_maps_flutter_android:
     dependency: transitive
     description:
@@ -590,6 +604,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.2.4"
+  google_maps_flutter_web:
+    dependency: transitive
+    description:
+      name: google_maps_flutter_web
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.5.1"
   graphs:
     dependency: transitive
     description:
@@ -604,6 +625,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.1.6"
+  html:
+    dependency: transitive
+    description:
+      name: html
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.15.3"
   http:
     dependency: "direct main"
     description:
@@ -653,6 +681,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.6.4"
+  js_wrapping:
+    dependency: transitive
+    description:
+      name: js_wrapping
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.7.4"
   json_annotation:
     dependency: transitive
     description:
@@ -919,6 +954,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.27.3"
+  sanitize_html:
+    dependency: transitive
+    description:
+      name: sanitize_html
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.0"
   shared_preferences:
     dependency: "direct main"
     description:
@@ -1241,4 +1283,4 @@ packages:
     version: "3.1.0"
 sdks:
   dart: ">=2.18.0 <3.0.0"
-  flutter: ">=3.0.0"
+  flutter: ">=3.3.0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -140,42 +140,14 @@ packages:
       name: connectivity_plus
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.3.9"
-  connectivity_plus_linux:
-    dependency: transitive
-    description:
-      name: connectivity_plus_linux
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.3.0"
-  connectivity_plus_macos:
-    dependency: transitive
-    description:
-      name: connectivity_plus_macos
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.2.6"
+    version: "4.0.2"
   connectivity_plus_platform_interface:
     dependency: transitive
     description:
       name: connectivity_plus_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
-  connectivity_plus_web:
-    dependency: transitive
-    description:
-      name: connectivity_plus_web
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.2.5"
-  connectivity_plus_windows:
-    dependency: transitive
-    description:
-      name: connectivity_plus_windows
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.2.2"
+    version: "1.2.4"
   convert:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -65,7 +65,7 @@ dependencies:
   font_awesome_flutter: ^10.2.1
   in_app_review: ^2.0.6
   device_info_plus: ^4.0.0
-  pub_semver: ^2.1.0
+  pub_semver: ^2.1.4
   home_widget: ^0.1.6
   marquee: 2.2.1
   auto_size_text: ^3.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -54,7 +54,7 @@ dependencies:
   shared_preferences: ^2.0.15
   webview_flutter: ^3.0.4
   flutter_custom_tabs: ^1.0.4
-  google_maps_flutter: ^2.2.1
+  google_maps_flutter: ^2.3.0
   github: ^9.1.0
   package_info_plus: ^1.4.2
   feature_discovery: ^0.14.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ description: The 4th generation of ÉTSMobile, the main gateway between the Éco
 # pub.dev using `pub publish`. This is preferred for private packages.
 publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 
-version: 4.23.1+1
+version: 4.23.2+1
 
 environment:
   sdk: ">=2.10.0 <3.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -60,7 +60,7 @@ dependencies:
   feature_discovery: ^0.14.0
   path_provider: ^2.0.11
   rive: ^0.9.1
-  connectivity_plus: ^2.3.7
+  connectivity_plus: ^4.0.2
   flutter_svg: ^1.0.3
   font_awesome_flutter: ^10.2.1
   in_app_review: ^2.0.6


### PR DESCRIPTION
## 📖 Description
[Bump CumulusDS/get-yaml-paths-action from 1.0.1 to 1.0.2](https://github.com/ApplETS/Notre-Dame/commit/bd77460fe8554186dd85f0653c0952f3eda4e933)
[Bump pub_semver from 2.1.1 to 2.1.4](https://github.com/ApplETS/Notre-Dame/commit/03b7537fd20e3dcaa15ca0ac63d54098e329ae34)
[Bump google_maps_flutter from 2.2.1 to 2.3.0](https://github.com/ApplETS/Notre-Dame/commit/0f724de82b9c143c21134efdfdc21d6c8a42963c)
[Bump connectivity_plus from 2.3.9 to 4.0.2](https://github.com/ApplETS/Notre-Dame/commit/ba6de22d149694fc58d327393939fb7c1140974f)

### 🧪 How Has This Been Tested?
I launched the application on each bump and navigated through the app too see if something was broken.

### ☑️ Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.
- [x] If needed, I added analytics.
- [x] Make sure to add either one of the following labels: `version: Major`,`version: Minor` or `version: Patch`. 
- [x] Make sure golden files changes were reviewed and approved.
