### PR TITLE
Fix program selection for profile page

### DIFF
--- a/lib/core/constants/programs_credits.dart
+++ b/lib/core/constants/programs_credits.dart
@@ -7,9 +7,7 @@ class ProgramCredits {
     "6556": 117,
     "6557": 118,
     "7086": 116,
-    // TODO: Ajouter le code lorsque le programme sera en vigeur
-    // (https://www.etsmtl.ca/etudes/premier-cycle/Baccalaureat-informatique-distribuee)
-    // "À venir" : 90",
+    "6646": 90,
     "5766": 30,
     "4567": 30,
     "4412": 30,

--- a/lib/core/viewmodels/profile_viewmodel.dart
+++ b/lib/core/viewmodels/profile_viewmodel.dart
@@ -51,21 +51,27 @@ class ProfileViewModel extends FutureViewModel<List<Program>> {
     int percentage = 0;
 
     if (programList.isNotEmpty) {
+      Program currentProgram = programList.first;
+      for (final program in programList) {
+        if (int.parse(program.registeredCredits) >
+            int.parse(currentProgram.registeredCredits)) {
+          currentProgram = program;
+        }
+      }
       final int numberOfCreditsCompleted =
-          int.parse(programList[programList.length - 1].accumulatedCredits);
-      final String code = programList[programList.length - 1].code;
+          int.parse(currentProgram.accumulatedCredits);
+      final String code = currentProgram.code;
       bool foundMatch = false;
 
       programCredits.programsCredits.forEach((key, value) {
-        if (key == code ||
-            programList[programList.length - 1].name.startsWith(key)) {
+        if (key == code || currentProgram.name.startsWith(key)) {
           percentage = (numberOfCreditsCompleted / value * 100).round();
           foundMatch = true;
         }
       });
 
       if (!foundMatch) {
-        final String programName = programList[programList.length - 1].name;
+        final String programName = currentProgram.name;
         analyticsService.logEvent("profile_view",
             'The program $programName (code: $code) does not match any program');
         percentage = 0;

--- a/lib/core/viewmodels/profile_viewmodel.dart
+++ b/lib/core/viewmodels/profile_viewmodel.dart
@@ -97,6 +97,8 @@ class ProfileViewModel extends FutureViewModel<List<Program>> {
     }
 
     _programList.sort((a, b) => b.status.compareTo(a.status));
+    _programList
+        .sort((a, b) => a.registeredCredits.compareTo(b.registeredCredits));
 
     return _programList;
   }


### PR DESCRIPTION
### ⁉️ Related Issue
Fixes: #845

## 📖 Description
I added the new program code in the program credits enum. (Source of the data is my account, I'm in the program)
I added a check to the profile page to set the current program based on the number of credits currently in progress in that program.

### 🧪 How Has This Been Tested?
As far as my understand of the app goes, the modified part of the view model is self contained and doesn't interact with other parts of the app. The existing unit tests for the widget have been check and all have passed. 

### ☑️ Checklist before requesting a review
- [✔] I have performed a self-review of my code.
- [N/A] If it is a core feature, I have added thorough tests.
- [N/A] If needed, I added analytics.
- [✔️] Make sure to add either one of the following labels: `version: Major`,`version: Minor` or `version: Patch`. 
- [ ] Make sure golden files changes were reviewed and approved.

### 🖼️ Screenshots (if useful):
Personal information removed for privacy reasons.
Before:
![image](https://github.com/ApplETS/Notre-Dame/assets/33943616/2fdb4057-6353-44e8-8244-f0bc494a0728)
After:
![Screenshot_1695066744](https://github.com/ApplETS/Notre-Dame/assets/33943616/322724ec-5072-4f58-861f-ef7affe5cc3a)
