### PR TITLE
Change broadcast card launch url logic to webview

### DIFF
--- a/lib/core/viewmodels/dashboard_viewmodel.dart
+++ b/lib/core/viewmodels/dashboard_viewmodel.dart
@@ -9,6 +9,9 @@ import 'package:ets_api_clients/models.dart';
 import 'package:feature_discovery/feature_discovery.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:fluttertoast/fluttertoast.dart';
+import 'package:notredame/core/constants/router_paths.dart';
+import 'package:notredame/core/services/launch_url_service.dart';
+import 'package:notredame/core/services/navigation_service.dart';
 import 'package:stacked/stacked.dart';
 
 // Project imports:
@@ -138,6 +141,17 @@ class DashboardViewModel extends FutureViewModel<Map<PreferencesFlag, int>> {
       return true;
     }
     return false;
+  }
+
+  static Future<void> launchBroadcastUrl(String url) async {
+    final LaunchUrlService launchUrlService = locator<LaunchUrlService>();
+    final NavigationService navigationService = locator<NavigationService>();
+    try {
+      await launchUrlService.launchInBrowser(url, Brightness.light);
+    } catch (error) {
+      // An exception is thrown if browser app is not installed on Android device.
+      await navigationService.pushNamed(RouterPaths.webView, arguments: url);
+    }
   }
 
   void changeProgressBarText() {

--- a/lib/ui/views/dashboard_view.dart
+++ b/lib/ui/views/dashboard_view.dart
@@ -465,7 +465,7 @@ class _DashboardViewState extends State<DashboardView>
       case "link":
         return IconButton(
           onPressed: () {
-            Utils.launchURL(url, AppIntl.of(context));
+            DashboardViewModel.launchBroadcastUrl(url);
           },
           icon: const Icon(
             Icons.open_in_new,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ description: The 4th generation of ÉTSMobile, the main gateway between the Éco
 # pub.dev using `pub publish`. This is preferred for private packages.
 publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 
-version: 4.30.0+1
+version: 4.30.1+1
 
 environment:
   sdk: ">=2.10.0 <3.0.0"


### PR DESCRIPTION
## 📖 Description
On Android, the broadcast card, when type = link, launched a native webview with limited controls. The webview has been changed to the already integrated one in the app.

### ☑️ Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.
- [x] If needed, I added analytics.
- [x] Make sure to add either one of the following labels: `version: Major`,`version: Minor` or `version: Patch`. 
- [x] Make sure golden files changes were reviewed and approved.
