### PR TITLE
Fix repeated colors in schedule calendar view

### DIFF
--- a/lib/core/viewmodels/schedule_viewmodel.dart
+++ b/lib/core/viewmodels/schedule_viewmodel.dart
@@ -67,8 +67,7 @@ class ScheduleViewModel extends FutureViewModel<List<CourseActivity>> {
   final Map<String, Color> courseColors = {};
 
   /// The color palette corresponding to the schedule courses.
-  List<Color> schedulePaletteThemeLight =
-      AppTheme.schedulePaletteLight.toList();
+  List<Color> schedulePaletteTheme = AppTheme.schedulePalette.toList();
 
   /// Get current locale
   Locale get locale => _settingsManager.locale;
@@ -135,7 +134,7 @@ class ScheduleViewModel extends FutureViewModel<List<CourseActivity>> {
 
   Color getCourseColor(String courseName) {
     if (!courseColors.containsKey(courseName)) {
-      courseColors[courseName] = schedulePaletteThemeLight.removeLast();
+      courseColors[courseName] = schedulePaletteTheme.removeLast();
     }
     return courseColors[courseName];
   }

--- a/lib/ui/utils/app_theme.dart
+++ b/lib/ui/utils/app_theme.dart
@@ -39,29 +39,17 @@ class AppTheme {
   static const Color darkThemeAccent = Color(0xff424242);
 
   // Schedule color palettes
-  static const List<Color> schedulePaletteLight = [
+  static const List<Color> schedulePalette = [
     Color(0xfff1c40f),
     Color(0xff1abc9c),
-    Color(0xff2ecc71),
-    Color(0xff2ecc71),
+    Color(0xff7f8c8d),
+    Color(0xff16a085),
     Color(0xff2ecc71),
     Color(0xff3498db),
     Color(0xff9b59b6),
     Color(0xff34495e),
     Color(0xffe67e22),
-    Color(0xffe74c3c)
-  ];
-  static const List<Color> schedulePaletteDark = [
-    Color(0xfff39c12),
-    Color(0xff16a085),
-    Color(0xff27ae60),
-    Color(0xff2ecc71),
-    Color(0xff2ecc71),
-    Color(0xff2980b9),
-    Color(0xff8e44ad),
-    Color(0xff2c3e50),
-    Color(0xffd35400),
-    Color(0xffc0392b)
+    Color(0xffe74c3c),
   ];
 
   /// Schedule calendar colors


### PR DESCRIPTION
### ⁉️ Related Issue
When the schedule has more than 1 session worth of classes, we can start seeing repeated colors on the background of certain cards.

## 📖 Description
Change the colors in the schedule cards palette.
