### PR TITLE
Configs for quicklinks

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "font_awesome_flutter"]
+	path = font_awesome_flutter
+	url = git@github.com:ApplETS/font_awesome_flutter.git
+  branch = ets-mobile

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.5.31'
+    ext.kotlin_version = '1.9.21'
     repositories {
         google()
         mavenCentral()

--- a/lib/core/managers/quick_link_repository.dart
+++ b/lib/core/managers/quick_link_repository.dart
@@ -1,7 +1,11 @@
 // Dart imports:
 import 'dart:convert';
+import 'package:font_awesome_flutter/font_awesome_flutter.dart';
+import 'package:notredame/ui/utils/app_theme.dart';
+import 'package:font_awesome_flutter/name_icon_mapping.dart';
 
 // Package imports:
+import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 // Project imports:
@@ -9,10 +13,16 @@ import 'package:notredame/core/constants/quick_links.dart';
 import 'package:notredame/core/managers/cache_manager.dart';
 import 'package:notredame/core/models/quick_link.dart';
 import 'package:notredame/core/models/quick_link_data.dart';
+import 'package:notredame/core/services/firebase_storage_service.dart';
 import 'package:notredame/locator.dart';
+import 'package:notredame/core/services/remote_config_service.dart';
 
 class QuickLinkRepository {
   final CacheManager _cacheManager = locator<CacheManager>();
+  final RemoteConfigService _remoteConfigService =
+      locator<RemoteConfigService>();
+  final FirebaseStorageService _storageService =
+      locator<FirebaseStorageService>();
 
   static const String quickLinksCacheKey = "quickLinksCache";
 
@@ -36,7 +46,42 @@ class QuickLinkRepository {
         quickLinksCacheKey, jsonEncode(quickLinkDataList));
   }
 
-  List<QuickLink> getDefaultQuickLinks(AppIntl intl) {
-    return quickLinks(intl);
+  Future<List<QuickLink>> getDefaultQuickLinks(AppIntl intl) async {
+    final values = await _remoteConfigService.quicklinks_values;
+
+    if (values == null || values as List == null || (values as List).isEmpty) {
+      return quickLinks(intl);
+    }
+    final listValues = values as List<dynamic>;
+    final List<QuickLink> listQuicklink = [];
+
+    for (var i = 0; i < listValues.length; i++) {
+      Widget imageWidget;
+      Map<String, dynamic> map = listValues[i] as Map<String, dynamic>;
+
+      if (map['icon'] != null) {
+        final String iconName = map['icon'] as String;
+        imageWidget = FaIcon(
+          faIconNameMapping['solid $iconName'],
+          color: AppTheme.etsLightRed,
+          size: 64,
+        );
+      } else if (map['remotePath'] != null) {
+        final remoteUrl =
+            await _storageService.getImageUrl(map['remotePath'] as String);
+        imageWidget = Image.network(
+          remoteUrl,
+          color: AppTheme.etsLightRed,
+        );
+      }
+      final QuickLink quickLink =
+          QuickLink.fromJson(listValues[i] as Map<String, dynamic>);
+      quickLink.name =
+          intl.localeName == "fr" ? quickLink.nameFr : quickLink.nameEn;
+      quickLink.image = imageWidget;
+      listQuicklink.add(quickLink);
+    }
+
+    return listQuicklink;
   }
 }

--- a/lib/core/managers/quick_link_repository.dart
+++ b/lib/core/managers/quick_link_repository.dart
@@ -1,7 +1,6 @@
 // Dart imports:
 import 'dart:convert';
 import 'package:cached_network_image/cached_network_image.dart';
-import 'package:flutter/foundation.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 import 'package:notredame/ui/utils/app_theme.dart';
 import 'package:font_awesome_flutter/name_icon_mapping.dart';
@@ -74,13 +73,7 @@ class QuickLinkRepository {
         try {
           imageUrl = await _cacheManager.get(remotePathKey);
         } on Exception catch (_) {
-          if (kDebugMode) {
-            print(
-                "Image not in cache, fetching from cloud storage: $remotePathKey");
-          }
-
-          imageUrl =
-              await _storageService.getImageUrl(map['remotePath'] as String);
+          imageUrl = await _storageService.getImageUrl(remotePathKey);
           _cacheManager.update(remotePathKey, imageUrl);
         }
 

--- a/lib/core/models/quick_link.dart
+++ b/lib/core/models/quick_link.dart
@@ -3,13 +3,27 @@ import 'package:flutter/material.dart';
 
 class QuickLink {
   final int id;
-  final Widget image;
-  final String name;
+  Widget image;
   final String link;
+  final String nameFr;
+  final String nameEn;
+  String name;
 
+  // If name is provided it will be used instead of nameFr and nameEn
   QuickLink(
       {@required this.id,
-      @required this.image,
-      @required this.name,
+      this.image,
+      this.name,
+      this.nameFr,
+      this.nameEn,
       @required this.link});
+
+  factory QuickLink.fromJson(Map<String, dynamic> json) {
+    return QuickLink(
+      id: int.parse(json['id'] as String),
+      nameFr: json['nameFr'] as String,
+      nameEn: json['nameEn'] as String,
+      link: json['link'] as String,
+    );
+  }
 }

--- a/lib/core/services/course_grade_cache_service.dart
+++ b/lib/core/services/course_grade_cache_service.dart
@@ -1,0 +1,57 @@
+// Package imports:
+import 'package:firebase_analytics/firebase_analytics.dart';
+
+/// Manage the analytics of the application
+class CourseGradeCacheService {
+  final FirebaseAnalytics _analytics = FirebaseAnalytics.instance;
+
+  CourseGradeCacheService();
+
+  void setCourseGradeCache(String semester, String courseCode,
+      String courseName, double courseGrade) {
+    _analytics.logEvent(name: "setCourseGradeCache");
+  }
+}
+
+class SemesterCache {
+  final String semester;
+  final List<GradeCache> gradeCacheList;
+
+  SemesterCache({this.semester, this.gradeCacheList});
+
+  factory SemesterCache.fromJson(Map<String, dynamic> json) {
+    return SemesterCache(
+      semester: json['semester'] as String,
+      gradeCacheList: (json['gradeCacheList'] as List<dynamic>)
+          .map((e) => GradeCache.fromJson(e as Map<String, dynamic>))
+          .toList(),
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+        'semester': semester,
+        'gradeCacheList': gradeCacheList.map((e) => e.toJson()),
+      };
+}
+
+class GradeCache {
+  final String courseCode;
+  final String courseName;
+  final double courseGrade;
+
+  GradeCache({this.courseCode, this.courseName, this.courseGrade});
+
+  factory GradeCache.fromJson(Map<String, dynamic> json) {
+    return GradeCache(
+      courseCode: json['courseCode'] as String,
+      courseName: json['courseName'] as String,
+      courseGrade: json['courseGrade'] as double,
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+        'courseCode': courseCode,
+        'courseName': courseName,
+        'courseGrade': courseGrade,
+      };
+}

--- a/lib/core/services/firebase_storage_service.dart
+++ b/lib/core/services/firebase_storage_service.dart
@@ -1,0 +1,34 @@
+// Package imports:
+import 'package:firebase_storage/firebase_storage.dart';
+
+// Project imports:
+import 'package:notredame/core/services/analytics_service.dart';
+import 'package:notredame/locator.dart';
+
+/// Manage the analytics of the application
+class FirebaseStorageService {
+  static const String tag = "FirebaseStorageService";
+  static const String _defaultPath = "app-images";
+
+  final FirebaseStorage _firebaseStorage = FirebaseStorage.instance;
+
+  final AnalyticsService _analyticsService = locator<AnalyticsService>();
+
+  /// Reference to the app images folder in default cloud storage
+  Reference _appImageReferences;
+
+  /// Get the url of the image from the firebase storage
+  /// [fileName] is the fileName of the image in the firebase storage
+  Future<String> getImageUrl(String fileName) async {
+    try {
+      _appImageReferences ??= _firebaseStorage.ref(_defaultPath);
+      final child = _appImageReferences.child(fileName);
+      final url = await child.getDownloadURL();
+      return url;
+    } catch (e) {
+      _analyticsService.logError(
+          tag, "Error while getting the image url", e as Exception);
+      rethrow;
+    }
+  }
+}

--- a/lib/core/services/firebase_storage_service.dart
+++ b/lib/core/services/firebase_storage_service.dart
@@ -1,5 +1,6 @@
 // Package imports:
 import 'package:firebase_storage/firebase_storage.dart';
+import 'package:flutter/cupertino.dart';
 
 // Project imports:
 import 'package:notredame/core/services/analytics_service.dart';
@@ -10,24 +11,32 @@ class FirebaseStorageService {
   static const String tag = "FirebaseStorageService";
   static const String _defaultPath = "app-images";
 
-  final FirebaseStorage _firebaseStorage = FirebaseStorage.instance;
+  FirebaseStorage firebaseStorage;
 
   final AnalyticsService _analyticsService = locator<AnalyticsService>();
 
   /// Reference to the app images folder in default cloud storage
   Reference _appImageReferences;
 
+  @visibleForTesting
+  Reference get appImageReferences => _appImageReferences;
+
+  FirebaseStorageService({this.firebaseStorage}) {
+    firebaseStorage ??= FirebaseStorage.instance;
+    _appImageReferences = firebaseStorage.ref(_defaultPath);
+  }
+
   /// Get the url of the image from the firebase storage
   /// [fileName] is the fileName of the image in the firebase storage
   Future<String> getImageUrl(String fileName) async {
     try {
-      _appImageReferences ??= _firebaseStorage.ref(_defaultPath);
+      _appImageReferences ??= firebaseStorage.ref(_defaultPath);
+
       final child = _appImageReferences.child(fileName);
       final url = await child.getDownloadURL();
       return url;
-    } catch (e) {
-      _analyticsService.logError(
-          tag, "Error while getting the image url", e as Exception);
+    } on Exception catch (e) {
+      _analyticsService.logError(tag, "Error while getting the image url", e);
       rethrow;
     }
   }

--- a/lib/core/services/remote_config_service.dart
+++ b/lib/core/services/remote_config_service.dart
@@ -1,13 +1,11 @@
-//SERVICE
-
 // Package imports:
+import 'dart:convert';
+
 import 'package:firebase_remote_config/firebase_remote_config.dart';
 
 // Project imports:
 import 'package:notredame/core/services/analytics_service.dart';
 import 'package:notredame/locator.dart';
-
-//OTHERS
 
 /// Manage the analytics of the application
 class RemoteConfigService {
@@ -26,6 +24,7 @@ class RemoteConfigService {
   static const _dashboardMsgColor = "dashboard_message_color";
   static const _dashboardMsgUrl = "dashboard_message_url";
   static const _dashboardMsgType = "dashboard_message_type";
+  static const _quicklinksValues = "quicklinks_values";
 
   static const _scheduleListViewDefault = "schedule_list_view_default";
   final FirebaseRemoteConfig _remoteConfig = FirebaseRemoteConfig.instance;
@@ -106,6 +105,11 @@ class RemoteConfigService {
   String get dashboardMsgType {
     fetch();
     return _remoteConfig.getString(_dashboardMsgType);
+  }
+
+  Future<dynamic> get quicklinks_values async {
+    await fetch();
+    return jsonDecode(_remoteConfig.getString(_quicklinksValues));
   }
 
   Future<void> fetch() async {

--- a/lib/core/viewmodels/quick_links_viewmodel.dart
+++ b/lib/core/viewmodels/quick_links_viewmodel.dart
@@ -34,7 +34,7 @@ class QuickLinksViewModel extends FutureViewModel<List<QuickLink>> {
 
     // otherwise, return quickLinks according to the cache
     final defaultQuickLinks =
-        _quickLinkRepository.getDefaultQuickLinks(_appIntl);
+        await _quickLinkRepository.getDefaultQuickLinks(_appIntl);
     quickLinkDataList.sort((a, b) => a.index.compareTo(b.index));
     return quickLinkDataList
         .map((data) => defaultQuickLinks
@@ -47,8 +47,8 @@ class QuickLinksViewModel extends FutureViewModel<List<QuickLink>> {
     final currentQuickLinkIds = quickLinkList.map((e) => e.id).toList();
 
     // Return those not in current quick links but in default list
-    return _quickLinkRepository
-        .getDefaultQuickLinks(_appIntl)
+    final defaults = await _quickLinkRepository.getDefaultQuickLinks(_appIntl);
+    return defaults
         .where((element) => !currentQuickLinkIds.contains(element.id))
         .toList();
   }

--- a/lib/locator.dart
+++ b/lib/locator.dart
@@ -12,6 +12,7 @@ import 'package:notredame/core/managers/settings_manager.dart';
 import 'package:notredame/core/managers/user_repository.dart';
 import 'package:notredame/core/services/analytics_service.dart';
 import 'package:notredame/core/services/app_widget_service.dart';
+import 'package:notredame/core/services/firebase_storage_service.dart';
 import 'package:notredame/core/services/github_api.dart';
 import 'package:notredame/core/services/in_app_review_service.dart';
 import 'package:notredame/core/services/internal_info_service.dart';
@@ -35,6 +36,7 @@ void setupLocator() {
   locator.registerLazySingleton(() => const FlutterSecureStorage());
   locator.registerLazySingleton(() => PreferencesService());
   locator.registerLazySingleton(() => NetworkingService());
+  locator.registerLazySingleton(() => FirebaseStorageService());
   locator.registerLazySingleton(() => SirenFlutterService());
   locator.registerLazySingleton(() => AppWidgetService());
   locator.registerLazySingleton(() => InAppReviewService());

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -14,7 +14,7 @@ packages:
       name: _flutterfire_internals
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.12"
+    version: "1.3.7"
   analyzer:
     dependency: transitive
     description:
@@ -324,21 +324,21 @@ packages:
       name: firebase_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.4.1"
+    version: "2.17.0"
   firebase_core_platform_interface:
     dependency: transitive
     description:
       name: firebase_core_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.5.2"
+    version: "4.8.0"
   firebase_core_web:
     dependency: transitive
     description:
       name: firebase_core_web
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.8.0"
   firebase_crashlytics:
     dependency: "direct main"
     description:
@@ -374,6 +374,27 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.1.18"
+  firebase_storage:
+    dependency: "direct main"
+    description:
+      name: firebase_storage
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "11.2.8"
+  firebase_storage_platform_interface:
+    dependency: transitive
+    description:
+      name: firebase_storage_platform_interface
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "4.4.7"
+  firebase_storage_web:
+    dependency: transitive
+    description:
+      name: firebase_storage_web
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "3.6.8"
   fixnum:
     dependency: transitive
     description:
@@ -530,9 +551,9 @@ packages:
   font_awesome_flutter:
     dependency: "direct main"
     description:
-      name: font_awesome_flutter
-      url: "https://pub.dartlang.org"
-    source: hosted
+      path: font_awesome_flutter
+      relative: true
+    source: path
     version: "10.2.1"
   get_it:
     dependency: "direct main"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -26,6 +26,7 @@ dependencies:
   firebase_analytics: ^10.0.6
   firebase_crashlytics: ^3.0.6
   firebase_remote_config: ^3.0.6
+  firebase_storage: ^11.0.6
 
   # Utils
   logger: ^1.0.0
@@ -75,6 +76,10 @@ dependencies:
   reorderable_grid_view: ^2.2.6
   import_sorter: ^4.6.0
   flutter_keychain: ^2.4.0
+
+dependency_overrides:
+  font_awesome_flutter:
+    path: ./font_awesome_flutter
 
 dev_dependencies:
   flutter_test:

--- a/test/helpers.dart
+++ b/test/helpers.dart
@@ -341,7 +341,7 @@ QuickLinkRepository setupQuickLinkRepositoryMock() {
 }
 
 /// Load a mock of the [FirebaseStorageService]
-FirebaseStorageServiceMock setupFirebaseStorageServiceMock() {
+FirebaseStorageService setupFirebaseStorageServiceMock() {
   unregister<FirebaseStorageService>();
   final storage = FirebaseStorageServiceMock();
 

--- a/test/helpers.dart
+++ b/test/helpers.dart
@@ -19,6 +19,7 @@ import 'package:notredame/core/managers/settings_manager.dart';
 import 'package:notredame/core/managers/user_repository.dart';
 import 'package:notredame/core/services/analytics_service.dart';
 import 'package:notredame/core/services/app_widget_service.dart';
+import 'package:notredame/core/services/firebase_storage_service.dart';
 import 'package:notredame/core/services/github_api.dart';
 import 'package:notredame/core/services/in_app_review_service.dart';
 import 'package:notredame/core/services/internal_info_service.dart';
@@ -37,6 +38,7 @@ import 'mock/managers/settings_manager_mock.dart';
 import 'mock/managers/user_repository_mock.dart';
 import 'mock/services/analytics_service_mock.dart';
 import 'mock/services/app_widget_service_mock.dart';
+import 'mock/services/firebase_storage_mock.dart';
 import 'mock/services/flutter_secure_storage_mock.dart';
 import 'mock/services/github_api_mock.dart';
 import 'mock/services/in_app_review_service_mock.dart';
@@ -336,6 +338,16 @@ QuickLinkRepository setupQuickLinkRepositoryMock() {
   locator.registerSingleton<QuickLinkRepository>(repository);
 
   return repository;
+}
+
+/// Load a mock of the [FirebaseStorageService]
+FirebaseStorageServiceMock setupFirebaseStorageServiceMock() {
+  unregister<FirebaseStorageService>();
+  final storage = FirebaseStorageServiceMock();
+
+  locator.registerSingleton<FirebaseStorageService>(storage);
+
+  return storage;
 }
 
 bool getCalendarViewEnabled() {

--- a/test/mock/managers/quick_links_repository_mock.dart
+++ b/test/mock/managers/quick_links_repository_mock.dart
@@ -26,7 +26,7 @@ class QuickLinkRepositoryMock extends Mock implements QuickLinkRepository {
   /// Stub the function [getDefaultQuickLinks] of [mock] when called will return [toReturn].
   static void stubGetDefaultQuickLinks(QuickLinkRepositoryMock mock,
       {List<QuickLink> toReturn = const []}) {
-    when(mock.getDefaultQuickLinks(any)).thenAnswer((_) => toReturn);
+    when(mock.getDefaultQuickLinks(any)).thenAnswer((_) async => toReturn);
   }
 
   /// Stub the function [updateQuickLinkDataToCache] of [mock] when called will complete without errors.

--- a/test/mock/services/firebase_storage_mock.dart
+++ b/test/mock/services/firebase_storage_mock.dart
@@ -1,0 +1,16 @@
+// Package imports:
+import 'package:firebase_storage/firebase_storage.dart';
+import 'package:mockito/mockito.dart';
+
+// Project imports:
+import 'package:notredame/core/services/firebase_storage_service.dart';
+
+/// Mock for the [FirebaseStorageService]
+class FirebaseStorageServiceMock extends Mock
+    implements FirebaseStorageService {}
+
+/// Mock for the [FirebaseStorage]
+class FirebaseStorageMock extends Mock implements FirebaseStorage {}
+
+/// Mock for the [Reference]
+class ReferenceMock extends Mock implements Reference {}

--- a/test/services/firebase_storage_service_test.dart
+++ b/test/services/firebase_storage_service_test.dart
@@ -25,9 +25,9 @@ void main() {
       rootMock = ReferenceMock();
       childMock = ReferenceMock();
       firebaseStorageMock = FirebaseStorageMock();
-      when(firebaseStorageMock.ref("any-images")).thenReturn(rootMock);
+      when(firebaseStorageMock.ref("app-images")).thenReturn(rootMock);
 
-      when(firebaseStorageMock.ref("any-images")).thenReturn(rootMock);
+      when(firebaseStorageMock.ref("app-images")).thenReturn(rootMock);
       when(rootMock.child("test.png")).thenReturn(childMock);
       when(childMock.getDownloadURL())
           .thenAnswer((_) => Future.value("test-url"));
@@ -38,7 +38,7 @@ void main() {
     group("getImageUrl - ", () {
       test("get image url", () async {
         final url = await service.getImageUrl("test.png");
-        verify(firebaseStorageMock.ref("any-images"));
+        verify(firebaseStorageMock.ref("app-images"));
         verify(rootMock.child("test.png"));
         verify(childMock.getDownloadURL());
         expect(url, isNotNull);

--- a/test/services/firebase_storage_service_test.dart
+++ b/test/services/firebase_storage_service_test.dart
@@ -1,0 +1,49 @@
+// Package imports:
+import 'package:firebase_storage/firebase_storage.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+// Project imports:
+import 'package:notredame/core/services/firebase_storage_service.dart';
+import '../helpers.dart';
+import '../mock/services/firebase_storage_mock.dart';
+
+void main() {
+  FirebaseStorage firebaseStorageMock;
+  ReferenceMock rootMock;
+  ReferenceMock childMock;
+  FirebaseStorageService service;
+
+  SharedPreferences.setMockInitialValues({});
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group("FirebaseStorageService - ", () {
+    setUp(() async {
+      setupAnalyticsServiceMock();
+
+      rootMock = ReferenceMock();
+      childMock = ReferenceMock();
+      firebaseStorageMock = FirebaseStorageMock();
+      when(firebaseStorageMock.ref("any-images")).thenReturn(rootMock);
+
+      when(firebaseStorageMock.ref("any-images")).thenReturn(rootMock);
+      when(rootMock.child("test.png")).thenReturn(childMock);
+      when(childMock.getDownloadURL())
+          .thenAnswer((_) => Future.value("test-url"));
+
+      service = FirebaseStorageService(firebaseStorage: firebaseStorageMock);
+    });
+
+    group("getImageUrl - ", () {
+      test("get image url", () async {
+        final url = await service.getImageUrl("test.png");
+        verify(firebaseStorageMock.ref("any-images"));
+        verify(rootMock.child("test.png"));
+        verify(childMock.getDownloadURL());
+        expect(url, isNotNull);
+        expect(url, "test-url");
+      });
+    });
+  });
+}


### PR DESCRIPTION
### ⁉️ Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- For more explanation: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--- Please link the issue here: (use keyword `closes: #12345`) -->
No issues was made previously but a discussion was done in a coding session.

## 📖 Description
<!--- Describe your changes in detail -->
Here's a sneak peek of the changes:
- Added a new service to connect to firebase cloud storage `FirebaseStorageService`.
- Change dependency of font awesome to a forked version that is configured to use dynamic matcher from font name (We will need to maintain the repo).
  - In case we want to bump the version of font awesome, simply sync source with our fork and merge the wanted version with our used branch `ets-mobile`. [More details in wiki](url).
- Modify the `QuicklinkRepository.getDefaultQuicklink(AppIntl)`
  - Add a way to take icon from remote config json and render them as specified icon.
  - Add a way to handle using remote path for loading up custom icons.
  - `icon` and `remotePath` attributes are mutually exclusive which means one should be null if the other one is defined. In the case there is an error with the definition in remote config, icon will take precedence.
  - Custom icons loaded up from cloud storage are cached and url is only fetched when none is found in cache, this allows the fastest fetching possible for quicklinks­.


<details>
  <summary><h4>Example of remote config data</h4></summary>

  ```json
 [
    {
      "id": "1",
      "nameFr": "Sécurité",
      "nameEn": "Security",
      "icon": "shield-halved",
      "link": "security"
    },
    {
      "id": "2",
      "nameFr": "MonÉTS",
      "nameEn": "MonÉTS",
      "remotePath": "ic_monets_sans_nom_red.png",
      "link": "https://portail.etsmtl.ca/home"
    },
    {
      "id": "3",
      "nameFr": "Bibliotech",
      "nameEn": "Bibliotech",
      "icon": "book",
      "link": "https://www.etsmtl.ca/Bibliotheque/Accueil"
    },
    {
      "id": "4",
      "nameFr": "Nouvelles",
      "nameEn": "News",
      "icon": "newspaper",
      "link": "https://www.etsmtl.ca/nouvelles"
    },
    {
      "id": "5",
      "nameFr": "Bottin",
      "nameEn": "Directory",
      "icon": "address-book",
      "link": "https://www.etsmtl.ca/bottin"
    },
    {
      "id": "6",
      "nameFr": "Moodle",
      "nameEn": "Moodle",
      "remotePath": "ic_moodle_red.png",
      "link": "https://ena.etsmtl.ca/"
    },
    {
      "id": "7",
      "nameFr": "HorairÉTS",
      "nameEn": "HorairÉTS",
      "icon": "calendar",
      "link": "https://horairets.emmanuelcoulombe.dev/"
    },
    {
      "id": "8",
      "nameFr": "GUS",
      "nameEn": "GUS",
      "remotePath": "ic_gus_red.png",
      "link": "https://gus.etsmtl.ca/c2atom/mobile/login"
    },
    {
      "id": "9",
      "nameFr": "PaperCut",
      "nameEn": "PaperCut",
      "icon": "print",
      "link": "https://cls.etsmtl.ca/user"
    }
]
  ```
</details>

**Drawback**:
The main drawback of using a map to load up icons (which allows us to get them dynamically) is that there is no tree shaking for the unused resources. We would need to analyze if the app size is still acceptable. In the case it's not,  we would need to do manual cleansing of some dynamically provided key from font awesome package as read [here](https://github.com/fluttercommunity/font_awesome_flutter?tab=readme-ov-file#excluding-styles).


### 🧪 How Has This Been Tested?
Added a couple of test to extract default quicklinks from remote config and from cache and a test to getImageUrl from the newly created FirebaseStorageService.


### ☑️ Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.
- [x] If needed, I added analytics.
- [x] Make sure to add either one of the following labels: `version: Major`,`version: Minor` or `version: Patch`. 
- [x] Make sure golden files changes were reviewed and approved.

### 🖼️ Screenshots (if useful):
<!--- If it's a visual change, please provide a screenshot -->
<img width="1409" alt="image" src="https://github.com/ApplETS/Notre-Dame/assets/25663435/380ceb92-05b5-4752-b9cd-9d733c68fa1a">
<img width="1466" alt="image" src="https://github.com/ApplETS/Notre-Dame/assets/25663435/f385c163-b29f-4a72-a047-f417c11a9803">
<img width="1424" alt="image" src="https://github.com/ApplETS/Notre-Dame/assets/25663435/3231c7be-88a4-400f-869f-de5b7928a817">

