### PR TITLE
Add android themed icons support

### DIFF
--- a/android/app/src/main/res/mipmap-anydpi-v26/launcher_icon.xml
+++ b/android/app/src/main/res/mipmap-anydpi-v26/launcher_icon.xml
@@ -2,4 +2,5 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
   <background android:drawable="@color/ic_launcher_background"/>
   <foreground android:drawable="@drawable/ic_launcher_foreground"/>
+  <monochrome android:drawable="@drawable/ic_launcher_foreground"/>
 </adaptive-icon>

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ description: The 4th generation of ÉTSMobile, the main gateway between the Éco
 # pub.dev using `pub publish`. This is preferred for private packages.
 publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 
-version: 4.33.1+1
+version: 4.33.2+1
 
 environment:
   sdk: ">=2.10.0 <3.0.0"


### PR DESCRIPTION
### ⁉️ Related Issue
Closes #916

## 📖 Description
I really just added a single line of XML code, reusing the existing adaptive icon drawable

### 🧪 How Has This Been Tested?
Tested both in the emulator and on my own phone. Due to not having access to some required keys, and being unable to downgrade dart to the old version that you're using, I had to strip out all flutter code and build it as a normal android app, just for testing. The nature of the change probably doesn't warrant any additional testing.

### 🖼️ Screenshots
First screenshot shows the app launcher without Themed Icons enabled, and the second shows how it now looks with Themed Icons enabled.

<img src="https://github.com/ApplETS/Notre-Dame/assets/46636609/03e5d4cd-c2c8-4590-be39-04e7db76cc48" width="45%">
<img src="https://github.com/ApplETS/Notre-Dame/assets/46636609/6bd4408b-0151-4dfb-b0bd-220c6affef5f" width="45%">

The ÉTS icon's outline looks less sharp than other icons, I'm not sure what causes that. Since the source file is a PNG, I can't really edit it as I would've done with an SVG. That'll be ok I guess anyway, but if somebody has an SVG version of the icon with a sharper outline, it might look ever-so-slightly better.