### PR TITLE
Fixed missing cache keys when loading profile page on first install

### DIFF
--- a/lib/core/managers/course_repository.dart
+++ b/lib/core/managers/course_repository.dart
@@ -121,7 +121,7 @@ class CourseRepository {
             "$tag - getCoursesActivities: ${_coursesActivities?.length ?? 0} activities loaded from cache");
       } on CacheException catch (_) {
         _logger.e(
-            "$tag - getCoursesActivities: exception raised will trying to load activities from cache.");
+            "$tag - getCoursesActivities: exception raised while trying to load activities from cache.");
       }
     }
 
@@ -181,7 +181,7 @@ class CourseRepository {
     } on CacheException catch (_) {
       // Do nothing, the caching will retry later and the error has been logged by the [CacheManager]
       _logger.e(
-          "$tag - getCoursesActivities: exception raised will trying to update the cache.");
+          "$tag - getCoursesActivities: exception raised while trying to update the cache.");
     }
 
     return _coursesActivities;
@@ -220,7 +220,7 @@ class CourseRepository {
           "$tag - getScheduleDefaultActivities: ${_scheduleDefaultActivities.length} activities loaded from cache");
     } on CacheException catch (_) {
       _logger.e(
-          "$tag - getDefaultScheduleActivities: exception raised will trying to load activities from cache.");
+          "$tag - getDefaultScheduleActivities: exception raised while trying to load activities from cache.");
     }
 
     if (fromCacheOnly) {
@@ -254,7 +254,7 @@ class CourseRepository {
     } on CacheException catch (_) {
       // Do nothing, the caching will retry later and the error has been logged by the [CacheManager]
       _logger.e(
-          "$tag - getScheduleActivities: exception raised will trying to update the cache.");
+          "$tag - getScheduleActivities: exception raised while trying to update the cache.");
     }
 
     return _scheduleDefaultActivities;
@@ -287,7 +287,7 @@ class CourseRepository {
             "$tag - getScheduleActivities: ${_scheduleActivities!.length} activities loaded from cache");
       } on CacheException catch (_) {
         _logger.e(
-            "$tag - getScheduleActivities: exception raised will trying to load activities from cache.");
+            "$tag - getScheduleActivities: exception raised while trying to load activities from cache.");
       }
     }
 
@@ -338,7 +338,7 @@ class CourseRepository {
     } on CacheException catch (_) {
       // Do nothing, the caching will retry later and the error has been logged by the [CacheManager]
       _logger.e(
-          "$tag - getScheduleActivities: exception raised will trying to update the cache.");
+          "$tag - getScheduleActivities: exception raised while trying to update the cache.");
     }
 
     return _scheduleActivities!;
@@ -363,7 +363,7 @@ class CourseRepository {
             "$tag - getSessions: ${_sessions?.length ?? 0} sessions loaded from cache.");
       } on CacheException catch (_) {
         _logger.e(
-            "$tag - getSessions: exception raised will trying to load the sessions from cache.");
+            "$tag - getSessions: exception raised while trying to load the sessions from cache.");
       }
     }
 
@@ -394,7 +394,7 @@ class CourseRepository {
       }
     } on CacheException catch (_) {
       _logger.e(
-          "$tag - getSessions: exception raised will trying to update the cache.");
+          "$tag - getSessions: exception raised while trying to update the cache.");
       return _sessions!;
     } on Exception catch (e, stacktrace) {
       _analyticsService.logError(
@@ -430,7 +430,7 @@ class CourseRepository {
             "$tag - getCourses: ${_courses!.length} courses loaded from cache");
       } on CacheException catch (_) {
         _logger.e(
-            "$tag - getCourses: exception raised will trying to load courses from cache.");
+            "$tag - getCourses: exception raised while trying to load courses from cache.");
       }
     }
 
@@ -490,7 +490,7 @@ class CourseRepository {
     } on CacheException catch (_) {
       // Do nothing, the caching will retry later and the error has been logged by the [CacheManager]
       _logger.e(
-          "$tag - getCourses: exception raised will trying to update the cache.");
+          "$tag - getCourses: exception raised while trying to update the cache.");
     }
 
     return _courses!;
@@ -548,7 +548,7 @@ class CourseRepository {
       // Do nothing, the caching will retry later and
       // the error has been logged by the [CacheManager]
       _logger.e(
-          "$tag - getCourseSummary: exception raised will trying to update the cache.");
+          "$tag - getCourseSummary: exception raised while trying to update the cache.");
     }
 
     return course;

--- a/lib/core/managers/user_repository.dart
+++ b/lib/core/managers/user_repository.dart
@@ -196,11 +196,8 @@ class UserRepository {
   /// The list from the [CacheManager] is loaded than updated with the results
   /// from the [SignetsApi].
   Future<List<Program>> getPrograms({bool fromCacheOnly = false}) async {
-    bool encounteredMissingKey = false;
-
     // Force fromCacheOnly mode when user has no connectivity
-    final bool hasConnectivity = await _networkingService.hasConnectivity();
-    if (!hasConnectivity) {
+    if (!(await _networkingService.hasConnectivity())) {
       // ignore: parameter_assignments
       fromCacheOnly = true;
     }
@@ -220,19 +217,13 @@ class UserRepository {
             .toList();
         _logger.d(
             "$tag - getPrograms: ${_programs!.length} programs loaded from cache.");
-      } on CacheException catch (e) {
-        if (e
-            .toString()
-            .contains("$programsCacheKey doesn't exist in the cache")) {
-          encounteredMissingKey = true;
-        } else {
-          _logger.e(
-              "$tag - getPrograms: exception raised while trying to load the programs from cache.");
-        }
+      } on CacheException catch (_) {
+        _logger.e(
+            "$tag - getPrograms: exception raised while trying to load the programs from cache.");
       }
     }
 
-    if (fromCacheOnly && !encounteredMissingKey) {
+    if (fromCacheOnly) {
       return _programs!;
     }
 
@@ -265,12 +256,9 @@ class UserRepository {
   /// Get the profile information.
   /// The information from the [CacheManager] is loaded than updated with the results
   /// from the [SignetsApi].
-  Future<ProfileStudent> getInfo({bool fromCacheOnly = false}) async {
-    bool encounteredMissingKey = false;
-
+  Future<ProfileStudent?> getInfo({bool fromCacheOnly = false}) async {
     // Force fromCacheOnly mode when user has no connectivity
-    final bool hasConnectivity = await _networkingService.hasConnectivity();
-    if (!hasConnectivity) {
+    if (!(await _networkingService.hasConnectivity())) {
       // ignore: parameter_assignments
       fromCacheOnly = true;
     }
@@ -285,18 +273,14 @@ class UserRepository {
         _info = ProfileStudent.fromJson(infoCached);
         _logger.d("$tag - getInfo: $_info info loaded from cache.");
       } on CacheException catch (e) {
-        if (e.toString().contains("$infoCacheKey doesn't exist in the cache")) {
-          encounteredMissingKey = true;
-        } else {
-          _logger.e(
-              "$tag - getInfo: exception raised while trying to load the info from cache.",
-              error: e);
-        }
+        _logger.e(
+            "$tag - getInfo: exception raised while trying to load the info from cache.",
+            error: e);
       }
     }
 
-    if (fromCacheOnly && !encounteredMissingKey) {
-      return _info!;
+    if (fromCacheOnly) {
+      return _info;
     }
 
     try {

--- a/lib/core/managers/user_repository.dart
+++ b/lib/core/managers/user_repository.dart
@@ -199,7 +199,7 @@ class UserRepository {
     // Force fromCacheOnly mode when user has no connectivity
     if (!(await _networkingService.hasConnectivity())) {
       // ignore: parameter_assignments
-      fromCacheOnly = true;
+      fromCacheOnly = !await _networkingService.hasConnectivity();
     }
 
     // Load the programs from the cache if the list doesn't exist

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ description: The 4th generation of ÉTSMobile, the main gateway between the Éco
 # pub.dev using `pub publish`. This is preferred for private packages.
 publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 
-version: 4.39.0+1
+version: 4.38.2+1
 
 environment:
   sdk: ">=3.3.0 <4.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ description: The 4th generation of ÉTSMobile, the main gateway between the Éco
 # pub.dev using `pub publish`. This is preferred for private packages.
 publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 
-version: 4.38.1+1
+version: 4.39.0+1
 
 environment:
   sdk: ">=3.3.0 <4.0.0"


### PR DESCRIPTION
### ⁉️ Related Issue
Closes #944 

## 📖 Description
When launching the app right after it's installed, some cache keys don't exist.
When calling:
- `await _userRepository.getInfo(fromCacheOnly: true)`
- `await _userRepository.getPrograms(fromCacheOnly: true)`

we're getting the info and the programs exclusively from cache, even though they don't exist.

### 🧪 How Has This Been Tested?
- Running the unit tests
- Uninstalling the app, launching it with the new changes and observing that the profile page loads as expected. 

### ☑️ Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] If needed, I added analytics.
- [x] Make sure to add either one of the following labels: `version: Major`,`version: Minor` or `version: Patch`. 
    - *Not sure if this is `patch` or `minor`*
- [ ] Make sure golden files changes were reviewed and approved.
