### PR TITLE
Changes to accomodate multiple course reviews for a single course

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -34,7 +34,7 @@ PODS:
     - Firebase/RemoteConfig (= 10.22.0)
     - firebase_core
     - Flutter
-  - FirebaseABTesting (10.25.0):
+  - FirebaseABTesting (10.27.0):
     - FirebaseCore (~> 10.0)
   - FirebaseAnalytics (10.22.0):
     - FirebaseAnalytics/AdIdSupport (= 10.22.0)
@@ -58,9 +58,9 @@ PODS:
     - FirebaseCoreInternal (~> 10.0)
     - GoogleUtilities/Environment (~> 7.12)
     - GoogleUtilities/Logger (~> 7.12)
-  - FirebaseCoreExtension (10.25.0):
+  - FirebaseCoreExtension (10.27.0):
     - FirebaseCore (~> 10.0)
-  - FirebaseCoreInternal (10.25.0):
+  - FirebaseCoreInternal (10.27.0):
     - "GoogleUtilities/NSData+zlib (~> 7.8)"
   - FirebaseCrashlytics (10.22.0):
     - FirebaseCore (~> 10.5)
@@ -70,7 +70,7 @@ PODS:
     - GoogleUtilities/Environment (~> 7.8)
     - nanopb (< 2.30911.0, >= 2.30908.0)
     - PromisesObjC (~> 2.1)
-  - FirebaseInstallations (10.25.0):
+  - FirebaseInstallations (10.27.0):
     - FirebaseCore (~> 10.0)
     - GoogleUtilities/Environment (~> 7.8)
     - GoogleUtilities/UserDefaults (~> 7.8)
@@ -82,7 +82,7 @@ PODS:
     - FirebaseSharedSwift (~> 10.0)
     - GoogleUtilities/Environment (~> 7.8)
     - "GoogleUtilities/NSData+zlib (~> 7.8)"
-  - FirebaseSessions (10.25.0):
+  - FirebaseSessions (10.27.0):
     - FirebaseCore (~> 10.5)
     - FirebaseCoreExtension (~> 10.0)
     - FirebaseInstallations (~> 10.0)
@@ -91,7 +91,7 @@ PODS:
     - GoogleUtilities/UserDefaults (~> 7.13)
     - nanopb (< 2.30911.0, >= 2.30908.0)
     - PromisesSwift (~> 2.1)
-  - FirebaseSharedSwift (10.25.0)
+  - FirebaseSharedSwift (10.27.0)
   - Flutter (1.0.0)
   - flutter_config (0.0.1):
     - Flutter
@@ -308,16 +308,16 @@ SPEC CHECKSUMS:
   firebase_core: 100945864b4aedce3cfef0c62ab864858bf013cf
   firebase_crashlytics: 2b9ca6246501a03427eb43280be7615027e32142
   firebase_remote_config: 5ebb1bf2503404f6b24e64f117dc6c22c0498d4c
-  FirebaseABTesting: e6e3c3e0e35813874f571d1b7bdae2aab319dd38
+  FirebaseABTesting: 038a7d5f1e36ba7208cf34f6f596946d8f70d6c3
   FirebaseAnalytics: 8d0ff929c63b7f72260f332b86ccf569776b75d3
   FirebaseCore: 0326ec9b05fbed8f8716cddbf0e36894a13837f7
-  FirebaseCoreExtension: 8a47811d0b155501559ef05d089518152a0a1677
-  FirebaseCoreInternal: 910a81992c33715fec9263ca7381d59ab3a750b7
+  FirebaseCoreExtension: 4ec89dd0c6de93d6becde32122d68b7c35f6bf5d
+  FirebaseCoreInternal: 4b297a2d56063dbea2c1d0d04222d44a8d058862
   FirebaseCrashlytics: e568d68ce89117c80cddb04073ab9018725fbb8c
-  FirebaseInstallations: 91950fe859846fff0fbd296180909dd273103b09
+  FirebaseInstallations: 766dabca09fd94aef922538aaf144cc4a6fb6869
   FirebaseRemoteConfig: e1b992a94d3674dddbcaf5d0d31a0312156ceb1c
-  FirebaseSessions: c0939656253a1fa0e94ecc266ccf770cc8b33732
-  FirebaseSharedSwift: 0274086954b1b2d5fd7e829eccc587044d72a4ba
+  FirebaseSessions: 2fdf949f9e58295a57703ae8f2efc44f9fa3aa16
+  FirebaseSharedSwift: a03fe7a59ee646fef71099a887f774fe25d745b8
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
   flutter_config: f48f0d47a284f1791aacce2687eabb3309ba7a41
   flutter_custom_tabs_ios: 62439c843b2691aae516fd50119a01eb9755fff7

--- a/lib/core/managers/course_repository.dart
+++ b/lib/core/managers/course_repository.dart
@@ -469,7 +469,7 @@ class CourseRepository {
     // If there isn't the grade yet, will fetch the summary.
     // We don't do this for every course to avoid losing time.
     for (final course in fetchedCourses) {
-      course.reviews = _getReviewForCourse(course, fetchedCourseReviews);
+      course.reviews = _getReviewsForCourse(course, fetchedCourseReviews);
       if (course.grade == null) {
         try {
           await getCourseSummary(course);
@@ -589,7 +589,7 @@ class CourseRepository {
   }
 
   /// Get the evaluation for a course or null if not found.
-  List<CourseReview>? _getReviewForCourse(
+  List<CourseReview>? _getReviewsForCourse(
       Course course, Map<String, List<CourseReview>> reviews) {
     final reviewsList = reviews[course.session]
         ?.where((element) =>

--- a/lib/core/managers/course_repository.dart
+++ b/lib/core/managers/course_repository.dart
@@ -469,7 +469,7 @@ class CourseRepository {
     // If there isn't the grade yet, will fetch the summary.
     // We don't do this for every course to avoid losing time.
     for (final course in fetchedCourses) {
-      course.review = _getReviewForCourse(course, fetchedCourseReviews);
+      course.reviews = _getReviewForCourse(course, fetchedCourseReviews);
       if (course.grade == null) {
         try {
           await getCourseSummary(course);
@@ -589,11 +589,13 @@ class CourseRepository {
   }
 
   /// Get the evaluation for a course or null if not found.
-  CourseReview? _getReviewForCourse(
+  List<CourseReview>? _getReviewForCourse(
       Course course, Map<String, List<CourseReview>> reviews) {
-    // Todo: changer pour firstWhereOrNull après update de Collection
-    final review = reviews[course.session]?.where((element) =>
-        element.acronym == course.acronym && element.group == course.group);
-    return review?.isNotEmpty ?? false ? review?.first : null;
+    final reviewsList = reviews[course.session]
+        ?.where((element) =>
+            element.acronym == course.acronym && element.group == course.group)
+        .toList();
+
+    return reviewsList == null || reviewsList.isEmpty ? null : reviewsList;
   }
 }

--- a/lib/core/viewmodels/dashboard_viewmodel.dart
+++ b/lib/core/viewmodels/dashboard_viewmodel.dart
@@ -255,7 +255,8 @@ class DashboardViewModel extends FutureViewModel<Map<PreferencesFlag, int>> {
         } else if (course.summary != null &&
             course.summary!.markOutOf > 0 &&
             !(course.inReviewPeriod &&
-                (course.reviewCompleted != null && !course.reviewCompleted!))) {
+                (course.allReviewsCompleted != null &&
+                    !course.allReviewsCompleted!))) {
           return _appIntl.grades_grade_in_percentage(
               course.summary!.currentMarkInPercent.round());
         }

--- a/lib/ui/views/grade_details_view.dart
+++ b/lib/ui/views/grade_details_view.dart
@@ -131,7 +131,7 @@ class _GradesDetailsViewState extends State<GradesDetailsView>
     if (model.isBusy) {
       return const Center(child: CircularProgressIndicator());
     } else if (model.course.inReviewPeriod &&
-        !(model.course.reviewCompleted ?? true)) {
+        !(model.course.allReviewsCompleted ?? true)) {
       return Center(
         child: GradeNotAvailable(
             key: const Key("EvaluationNotCompleted"),

--- a/lib/ui/widgets/grade_button.dart
+++ b/lib/ui/widgets/grade_button.dart
@@ -58,7 +58,7 @@ class GradeButton extends StatelessWidget {
       return course.grade!;
     } else if (course.summary != null &&
         course.summary!.markOutOf > 0 &&
-        !(course.inReviewPeriod && !(course.reviewCompleted ?? false))) {
+        !(course.inReviewPeriod && !(course.allReviewsCompleted ?? false))) {
       return intl.grades_grade_in_percentage(
           course.summary!.currentMarkInPercent.round());
     }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -45,7 +45,7 @@ dependencies:
     #    path: ../ETS-API-Clients/
     git:
       url: https://github.com/ApplETS/ETS-API-Clients.git
-      ref: 1.2.1
+      ref: 1.2.5
 
   # Other
   http: ^1.2.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ description: The 4th generation of ÉTSMobile, the main gateway between the Éco
 # pub.dev using `pub publish`. This is preferred for private packages.
 publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 
-version: 4.40.0+1
+version: 4.40.1+1
 
 environment:
   sdk: ">=3.3.0 <4.0.0"

--- a/test/managers/course_repository_test.dart
+++ b/test/managers/course_repository_test.dart
@@ -1210,14 +1210,16 @@ void main() {
           grade: 'C+',
           numberOfCredits: 3,
           title: 'Cours générique',
-          review: CourseReview(
-              acronym: 'GEN101',
-              group: '02',
-              teacherName: 'April, Alain',
-              startAt: DateTime(2020),
-              endAt: DateTime(2020, 1, 1, 23, 59),
-              isCompleted: true,
-              type: 'Cours'));
+          reviews: <CourseReview>[
+            CourseReview(
+                acronym: 'GEN101',
+                group: '02',
+                teacherName: 'April, Alain',
+                startAt: DateTime(2020),
+                endAt: DateTime(2020, 1, 1, 23, 59),
+                isCompleted: true,
+                type: 'Cours')
+          ]);
       final Course courseWithGradeDuplicate = Course(
           acronym: 'GEN101',
           group: '02',
@@ -1670,14 +1672,16 @@ void main() {
             numberOfCredits: 3,
             title: 'Cours générique');
 
-        final CourseReview review = CourseReview(
-            acronym: 'GEN101',
-            group: '02',
-            teacherName: 'April, Alain',
-            startAt: DateTime(2021, 03, 19),
-            endAt: DateTime(2021, 03, 28, 23, 59),
-            type: 'Cours',
-            isCompleted: true);
+        final courseReviews = <CourseReview>[
+          CourseReview(
+              acronym: 'GEN101',
+              group: '02',
+              teacherName: 'April, Alain',
+              startAt: DateTime(2021, 03, 19),
+              endAt: DateTime(2021, 03, 28, 23, 59),
+              type: 'Cours',
+              isCompleted: true)
+        ];
 
         final Course updated = Course(
             acronym: 'GEN101',
@@ -1687,12 +1691,12 @@ void main() {
             programCode: '999',
             numberOfCredits: 3,
             title: 'Cours générique',
-            review: review);
+            reviews: courseReviews);
 
         SignetsAPIClientMock.stubGetCourses(signetsApiMock, username,
             coursesToReturn: [courseFetched]);
         SignetsAPIClientMock.stubGetCourseReviews(signetsApiMock, username,
-            session: session, reviewsToReturn: [review]);
+            session: session, reviewsToReturn: [courseReviews[0]]);
         CacheManagerMock.stubGet(
             cacheManagerMock, CourseRepository.coursesCacheKey, jsonEncode([]));
 

--- a/test/ui/views/grades_details_view_test.dart
+++ b/test/ui/views/grades_details_view_test.dart
@@ -51,14 +51,42 @@ void main() {
     ],
   );
 
-  final CourseReview reviewCompleted = CourseReview(
-      acronym: 'GEN101',
-      group: '02',
-      teacherName: 'TEST',
-      startAt: DateTime.now().subtract(const Duration(days: 1)),
-      endAt: DateTime.now().add(const Duration(days: 1)),
-      type: 'Cours',
-      isCompleted: true);
+  final completedCourseReview = CourseReview(
+    acronym: 'GEN101',
+    group: '02',
+    teacherName: 'TEST',
+    startAt: DateTime.now().subtract(const Duration(days: 1)),
+    endAt: DateTime.now().add(const Duration(days: 1)),
+    type: 'Cours',
+    isCompleted: true,
+  );
+
+  final nonCompletedCourseReview = CourseReview(
+    acronym: 'GEN101',
+    group: '02',
+    teacherName: 'TEST',
+    startAt: DateTime.now().subtract(const Duration(days: 1)),
+    endAt: DateTime.now().add(const Duration(days: 1)),
+    type: 'Cours',
+    isCompleted: false,
+  );
+
+  final altNonCompletedCourseReview = CourseReview(
+    acronym: 'GEN101',
+    group: '02',
+    teacherName: 'TEST ALT',
+    startAt: DateTime.now().subtract(const Duration(days: 1)),
+    endAt: DateTime.now().add(const Duration(days: 1)),
+    type: 'Cours',
+    isCompleted: false,
+  );
+
+  final completedReviewList = <CourseReview>[completedCourseReview];
+  final nonCompletedReviewList = <CourseReview>[nonCompletedCourseReview];
+  final partiallyCompletedReviewList = <CourseReview>[
+    completedCourseReview,
+    altNonCompletedCourseReview
+  ];
 
   final Course course = Course(
       acronym: 'GEN101',
@@ -68,7 +96,7 @@ void main() {
       numberOfCredits: 3,
       title: 'Cours générique',
       summary: courseSummary,
-      review: reviewCompleted);
+      reviews: completedReviewList);
 
   final Course courseWithoutSummary = Course(
     acronym: 'GEN101',
@@ -87,14 +115,17 @@ void main() {
       numberOfCredits: 3,
       title: 'Cours générique',
       summary: courseSummary,
-      review: CourseReview(
-          acronym: 'GEN101',
-          group: '02',
-          teacherName: 'TEST',
-          startAt: DateTime.now().subtract(const Duration(days: 1)),
-          endAt: DateTime.now().add(const Duration(days: 1)),
-          type: 'Cours',
-          isCompleted: false));
+      reviews: nonCompletedReviewList);
+
+  final Course courseWithPartialEvaluationCompleted = Course(
+      acronym: 'GEN101',
+      group: '02',
+      session: 'H2020',
+      programCode: '999',
+      numberOfCredits: 3,
+      title: 'Cours générique',
+      summary: courseSummary,
+      reviews: partiallyCompletedReviewList);
 
   group('GradesDetailsView - ', () {
     setUp(() async {
@@ -265,6 +296,25 @@ void main() {
         setupFlutterToastMock(tester);
         CourseRepositoryMock.stubGetCourseSummary(courseRepositoryMock, course,
             toReturn: courseWithEvaluationNotCompleted);
+
+        tester.view.physicalSize = const Size(800, 1410);
+
+        await tester.pumpWidget(localizedWidget(
+            child: FeatureDiscovery(child: GradesDetailsView(course: course))));
+        await tester.pumpAndSettle(const Duration(seconds: 1));
+
+        await expectLater(
+            find.byType(GradesDetailsView),
+            matchesGoldenFile(
+                goldenFilePath("gradesDetailsView_evaluation_not_completed")));
+      });
+
+      testWidgets(
+          "if in the evaluation period and partially completed evaluation",
+          (WidgetTester tester) async {
+        setupFlutterToastMock(tester);
+        CourseRepositoryMock.stubGetCourseSummary(courseRepositoryMock, course,
+            toReturn: courseWithPartialEvaluationCompleted);
 
         tester.view.physicalSize = const Size(800, 1410);
 


### PR DESCRIPTION
### ⁉️ Related Issue
#941 

## 📖 Description

Instead of just getting the first course review, each course now has a list of course reviews. 
During the evaluation period, the student's grade will be `N/A` until **ALL** the course reviews have been completed.
Previously we only stored one, and because of this it would cause issues if there were more than 1 course review required for a single course.

*Note that the changes in this PR are dependant on https://github.com/ApplETS/ETS-API-Clients/pull/36.*

### 🧪 How Has This Been Tested?
This has been tested by running the unit tests.

### ☑️ Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.
- [ ] If needed, I added analytics.
- [x] Make sure to add either one of the following labels: `version: Major`,`version: Minor` or `version: Patch`. 
- [ ] Make sure golden files changes were reviewed and approved.
