### PR TITLE
Permettre aux utilisateurs sur iOS de swipe pour retourner à la page précédente

### DIFF
--- a/lib/features/app/navigation/router.dart
+++ b/lib/features/app/navigation/router.dart
@@ -73,9 +73,7 @@ Route<dynamic> generateRoute(RouteSettings routeSettings) {
     case RouterPaths.gradeDetails:
       return MaterialPageRoute(
         settings: RouteSettings(name: routeSettings.name),
-        builder: (context) {
-          return GradesDetailsView(course: routeSettings.arguments! as Course);
-        },
+        builder: (context) => GradesDetailsView(course: routeSettings.arguments! as Course);
       );
     case RouterPaths.ets:
       return PageRouteBuilder(
@@ -105,7 +103,7 @@ Route<dynamic> generateRoute(RouteSettings routeSettings) {
     case RouterPaths.webView:
       return MaterialPageRoute(
           settings: RouteSettings(name: routeSettings.name),
-          builder: (_) =>  LinkWebView(routeSettings.arguments! as QuickLink));
+          builder: (_) => LinkWebView(routeSettings.arguments! as QuickLink));
     case RouterPaths.security:
       return MaterialPageRoute(
           settings: RouteSettings(name: routeSettings.name),

--- a/lib/features/app/navigation/router.dart
+++ b/lib/features/app/navigation/router.dart
@@ -73,8 +73,7 @@ Route<dynamic> generateRoute(RouteSettings routeSettings) {
     case RouterPaths.gradeDetails:
       return MaterialPageRoute(
         settings: RouteSettings(name: routeSettings.name),
-        builder: (context) => GradesDetailsView(course: routeSettings.arguments! as Course);
-      );
+        builder: (context) => GradesDetailsView(course: routeSettings.arguments! as Course));
     case RouterPaths.ets:
       return PageRouteBuilder(
           settings: RouteSettings(name: routeSettings.name),

--- a/lib/features/app/navigation/router.dart
+++ b/lib/features/app/navigation/router.dart
@@ -72,8 +72,9 @@ Route<dynamic> generateRoute(RouteSettings routeSettings) {
           pageBuilder: (_, __, ___) => StudentView());
     case RouterPaths.gradeDetails:
       return MaterialPageRoute(
-        settings: RouteSettings(name: routeSettings.name),
-        builder: (context) => GradesDetailsView(course: routeSettings.arguments! as Course));
+          settings: RouteSettings(name: routeSettings.name),
+          builder: (context) =>
+              GradesDetailsView(course: routeSettings.arguments! as Course));
     case RouterPaths.ets:
       return PageRouteBuilder(
           settings: RouteSettings(name: routeSettings.name),
@@ -97,8 +98,8 @@ Route<dynamic> generateRoute(RouteSettings routeSettings) {
           settings: RouteSettings(
               name: routeSettings.name, arguments: routeSettings.arguments),
           pageBuilder: (_, __, ___) => AuthorView(
-            authorId: routeSettings.arguments! as String,
-          ));
+                authorId: routeSettings.arguments! as String,
+              ));
     case RouterPaths.webView:
       return MaterialPageRoute(
           settings: RouteSettings(name: routeSettings.name),

--- a/lib/features/app/navigation/router.dart
+++ b/lib/features/app/navigation/router.dart
@@ -71,24 +71,12 @@ Route<dynamic> generateRoute(RouteSettings routeSettings) {
           settings: RouteSettings(name: routeSettings.name),
           pageBuilder: (_, __, ___) => StudentView());
     case RouterPaths.gradeDetails:
-      return PageRouteBuilder(
-          transitionDuration: const Duration(milliseconds: 600),
-          transitionsBuilder: (context, animation, secondaryAnimation, child) {
-            const begin = Offset(0.0, 1.0);
-            const end = Offset.zero;
-            const curve = Curves.ease;
-
-            final tween =
-                Tween(begin: begin, end: end).chain(CurveTween(curve: curve));
-
-            return SlideTransition(
-              position: animation.drive(tween),
-              child: child,
-            );
-          },
-          settings: RouteSettings(name: routeSettings.name),
-          pageBuilder: (_, __, ___) =>
-              GradesDetailsView(course: routeSettings.arguments! as Course));
+      return MaterialPageRoute(
+        settings: RouteSettings(name: routeSettings.name),
+        builder: (context) {
+          return GradesDetailsView(course: routeSettings.arguments! as Course);
+        },
+      );
     case RouterPaths.ets:
       return PageRouteBuilder(
           settings: RouteSettings(name: routeSettings.name),
@@ -112,37 +100,36 @@ Route<dynamic> generateRoute(RouteSettings routeSettings) {
           settings: RouteSettings(
               name: routeSettings.name, arguments: routeSettings.arguments),
           pageBuilder: (_, __, ___) => AuthorView(
-                authorId: routeSettings.arguments! as String,
-              ));
+            authorId: routeSettings.arguments! as String,
+          ));
     case RouterPaths.webView:
-      return PageRouteBuilder(
-          pageBuilder: (_, __, ___) =>
-              LinkWebView(routeSettings.arguments! as QuickLink));
-    case RouterPaths.security:
-      return PageRouteBuilder(
+      return MaterialPageRoute(
           settings: RouteSettings(name: routeSettings.name),
-          pageBuilder: (_, __, ___) => SecurityView());
+          builder: (_) =>  LinkWebView(routeSettings.arguments! as QuickLink));
+    case RouterPaths.security:
+      return MaterialPageRoute(
+          settings: RouteSettings(name: routeSettings.name),
+          builder: (_) => SecurityView());
     case RouterPaths.more:
       return PageRouteBuilder(
           settings: RouteSettings(name: routeSettings.name),
           pageBuilder: (_, __, ___) => MoreView());
     case RouterPaths.settings:
-      return PageRouteBuilder(
+      return MaterialPageRoute(
           settings: RouteSettings(name: routeSettings.name),
-          pageBuilder: (_, __, ___) => SettingsView());
+          builder: (_) => SettingsView());
     case RouterPaths.contributors:
-      return PageRouteBuilder(
+      return MaterialPageRoute(
           settings: RouteSettings(name: routeSettings.name),
-          pageBuilder: (_, __, ___) => ContributorsView());
+          builder: (_) => ContributorsView());
     case RouterPaths.feedback:
-      return PageRouteBuilder(
+      return MaterialPageRoute(
           settings: RouteSettings(name: routeSettings.name),
-          pageBuilder: (_, __, ___) => FeedbackView());
+          builder: (_) => FeedbackView());
     case RouterPaths.about:
-      return PageRouteBuilder(
-          transitionDuration: const Duration(seconds: 1),
+      return MaterialPageRoute(
           settings: RouteSettings(name: routeSettings.name),
-          pageBuilder: (_, __, ___) => AboutView());
+          builder: (_) => AboutView());
     case RouterPaths.chooseLanguage:
       return MaterialPageRoute(
           settings: RouteSettings(name: routeSettings.name),


### PR DESCRIPTION
### ⁉️ Related Issue
closes #722, #141

## 📖 Description
Pour les pages ou le geste devrait être possible, utilisation de MaterialPageRoute.
On perds l'animation où la page des notes arrive à l'écran depuis le bas.

### 🧪 How Has This Been Tested?
Sur iOS et Android

### ☑️ Checklist before requesting a review
- [X] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] If needed, I added analytics.
- [X] Make sure to add either one of the following labels: `version: Major`,`version: Minor` or `version: Patch`. 
- [ ] Make sure golden files changes were reviewed and approved.