### PR TITLE
Fixed empty schedule on sundays

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -60,7 +60,7 @@ PODS:
     - GoogleUtilities/Logger (~> 8.0)
   - FirebaseCoreExtension (11.4.1):
     - FirebaseCore (~> 11.0)
-  - FirebaseCoreInternal (11.6.0):
+  - FirebaseCoreInternal (11.7.0):
     - "GoogleUtilities/NSData+zlib (~> 8.0)"
   - FirebaseCrashlytics (11.4.0):
     - FirebaseCore (~> 11.4)
@@ -84,7 +84,7 @@ PODS:
     - FirebaseSharedSwift (~> 11.0)
     - GoogleUtilities/Environment (~> 8.0)
     - "GoogleUtilities/NSData+zlib (~> 8.0)"
-  - FirebaseRemoteConfigInterop (11.6.0)
+  - FirebaseRemoteConfigInterop (11.7.0)
   - FirebaseSessions (11.4.0):
     - FirebaseCore (~> 11.4)
     - FirebaseCoreExtension (~> 11.4)
@@ -94,7 +94,7 @@ PODS:
     - GoogleUtilities/UserDefaults (~> 8.0)
     - nanopb (~> 3.30910.0)
     - PromisesSwift (~> 2.1)
-  - FirebaseSharedSwift (11.6.0)
+  - FirebaseSharedSwift (11.7.0)
   - Flutter (1.0.0)
   - flutter_inappwebview_ios (0.0.1):
     - Flutter
@@ -305,13 +305,13 @@ SPEC CHECKSUMS:
   FirebaseAnalytics: 3feef9ae8733c567866342a1000691baaa7cad49
   FirebaseCore: e0510f1523bc0eb21653cac00792e1e2bd6f1771
   FirebaseCoreExtension: f1bc67a4702931a7caa097d8e4ac0a1b0d16720e
-  FirebaseCoreInternal: d98ab91e2d80a56d7b246856a8885443b302c0c2
+  FirebaseCoreInternal: d6c17dafc8dc33614733a8b52df78fcb4394c881
   FirebaseCrashlytics: 41bbdd2b514a8523cede0c217aee6ef7ecf38401
   FirebaseInstallations: 6ef4a1c7eb2a61ee1f74727d7f6ce2e72acf1414
   FirebaseRemoteConfig: 7655681d02417bc9b287338edb9d721ff79e1a4a
-  FirebaseRemoteConfigInterop: e75e348953352a000331eb77caf01e424248e176
+  FirebaseRemoteConfigInterop: ca12abf9da0003efd3a476b2dff4f7a04fd31b4f
   FirebaseSessions: 3f56f177d9e53a85021d16b31f9a111849d1dd8b
-  FirebaseSharedSwift: a4e5dfca3e210633bb3a3dfb94176c019211948b
+  FirebaseSharedSwift: a45efd84d60ebbfdcdbaebc66948af3630459e62
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
   flutter_inappwebview_ios: 6f63631e2c62a7c350263b13fa5427aedefe81d4
   flutter_secure_storage: d33dac7ae2ea08509be337e775f6b59f1ff45f12

--- a/lib/features/schedule/schedule_default/schedule_default_viewmodel.dart
+++ b/lib/features/schedule/schedule_default/schedule_default_viewmodel.dart
@@ -47,7 +47,7 @@ class ScheduleDefaultViewModel
         : eventData.activityLocation;
 
     final DateTime now = DateTime.now();
-    final int daysToAdd = eventData.dayOfTheWeek - now.weekday;
+    final int daysToAdd = eventData.dayOfTheWeek - getWeekDayIndex(now);
     final DateTime targetDate = now.add(Duration(days: daysToAdd));
     final DateTime newStartTime = DateTime(targetDate.year, targetDate.month,
         targetDate.day, eventData.startTime.hour, eventData.startTime.minute);
@@ -77,6 +77,11 @@ class ScheduleDefaultViewModel
       courseColors[courseName] = schedulePaletteThemeLight.removeLast();
     }
     return courseColors[courseName];
+  }
+
+  int getWeekDayIndex(DateTime dateTime) {
+    int weekday = dateTime.weekday;
+    return weekday == 7 ? 0 : weekday;
   }
 
   Future<void> refresh() async {

--- a/lib/features/schedule/schedule_default/schedule_default_viewmodel.dart
+++ b/lib/features/schedule/schedule_default/schedule_default_viewmodel.dart
@@ -47,7 +47,7 @@ class ScheduleDefaultViewModel
         : eventData.activityLocation;
 
     final DateTime now = DateTime.now();
-    final int daysToAdd = eventData.dayOfTheWeek - getWeekDayIndex(now);
+    final int daysToAdd = eventData.dayOfTheWeek - (now.weekday % 7);
     final DateTime targetDate = now.add(Duration(days: daysToAdd));
     final DateTime newStartTime = DateTime(targetDate.year, targetDate.month,
         targetDate.day, eventData.startTime.hour, eventData.startTime.minute);
@@ -77,11 +77,6 @@ class ScheduleDefaultViewModel
       courseColors[courseName] = schedulePaletteThemeLight.removeLast();
     }
     return courseColors[courseName];
-  }
-
-  int getWeekDayIndex(DateTime dateTime) {
-    int weekday = dateTime.weekday;
-    return weekday == 7 ? 0 : weekday;
   }
 
   Future<void> refresh() async {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ description: The 4th generation of ÉTSMobile, the main gateway between the Éco
 # pub.dev using `pub publish`. This is preferred for private packages.
 publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 
-version: 4.56.0
+version: 4.56.1
 
 environment:
   sdk: '>=3.6.0 <4.0.0'


### PR DESCRIPTION
### ⁉️ Related Issue

Closes #1127 

## 📖 Description

The issue is because `.weekday` returns the weekday index with Monday (1) being the first day and Sunday (7) being the last.
When we try to calculate `daysToAdd` on a Sunday, we're doing `eventData.dayOfTheWeek - 7`.
For example if we have an event on Monday, the calculation will be `daysToAdd = 1 - 7`.
Because of this, the `targetDate` becomes `-6` (6 days in the past).
Since the date is in the past, it doesn't get show on the calendar because the default calendar only displays the current week.

I decided to create a method to return `0` as the index for Sunday instead of `7`.
I'm open to other solutions, I feel like this is the simplest solution at the moment.

### 🧪 How Has This Been Tested?
- Manual testing (changed the device's current date to all days of the week)
- Ran the unit tests

### ☑️ Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [x] If needed, I added analytics.
- [x] Make sure to add either one of the following labels: `version: Major`,`version: Minor` or `version: Patch`. 
