### PR TITLE
Bugfix/fix reset password link

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ assets/certificates/
 # Android related
 **/android/**/gradle-wrapper.jar
 **/android/.gradle
+**/android/app/.cxx/
 **/android/captures/
 **/android/gradlew
 **/android/gradlew.bat

--- a/l10n/intl_en.arb
+++ b/l10n/intl_en.arb
@@ -21,8 +21,8 @@
   "faq_questions_app_alert_password_assistance": "Password assistance",
   "continue_to_mail_app": "Continue to mail app",
   "cancel_button_text": "Cancel",
-  "monets_connection_help_page": "https://partage.etsmtl.ca/fs/en.html",
-    "website_open": "Visit the website",
+
+  "website_open": "Visit the website",
   "website_club_open": "Visit our club website",
   "facebook_open": "Visit our Facebook page",
   "instagram_open": "Visit our Instagram page",

--- a/l10n/intl_fr.arb
+++ b/l10n/intl_fr.arb
@@ -29,7 +29,6 @@
   "faq_questions_app_alert_password_assistance": "Assistance mot de passe",
   "continue_to_mail_app": "Continuer vers l'application courriel",
   "cancel_button_text": "Annuler",
-  "monets_connection_help_page": "https://partage.etsmtl.ca/fs/fr.html", 
 
   "close_button_text": "Fermer",
 

--- a/lib/ui/more/faq/view_model/faq_viewmodel.dart
+++ b/lib/ui/more/faq/view_model/faq_viewmodel.dart
@@ -3,12 +3,12 @@ import 'package:flutter/material.dart';
 
 // Package imports:
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
-import 'package:notredame/data/services/remote_config_service.dart';
 import 'package:stacked/stacked.dart';
 
 // Project imports:
 import 'package:notredame/data/repositories/settings_repository.dart';
 import 'package:notredame/data/services/launch_url_service.dart';
+import 'package:notredame/data/services/remote_config_service.dart';
 import 'package:notredame/domain/constants/app_info.dart';
 import 'package:notredame/locator.dart';
 
@@ -16,16 +16,18 @@ class FaqViewModel extends BaseViewModel {
   final SettingsRepository _settingsManager = locator<SettingsRepository>();
 
   final LaunchUrlService _launchUrlService = locator<LaunchUrlService>();
-  final RemoteConfigService _remoteConfigService = locator<RemoteConfigService>();
+  final RemoteConfigService _remoteConfigService =
+      locator<RemoteConfigService>();
 
   Locale? get locale => _settingsManager.locale;
 
   void launchWebsite(String link) {
     _launchUrlService.launchInBrowser(link);
   }
-  
+
   void launchPasswordReset() {
-    _launchUrlService.launchInBrowser(_remoteConfigService.signetsPasswordResetUrl);
+    _launchUrlService
+        .launchInBrowser(_remoteConfigService.signetsPasswordResetUrl);
   }
 
   Future<void> openMail(String addressEmail, BuildContext context) async {

--- a/lib/ui/more/faq/view_model/faq_viewmodel.dart
+++ b/lib/ui/more/faq/view_model/faq_viewmodel.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 
 // Package imports:
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:notredame/data/services/remote_config_service.dart';
 import 'package:stacked/stacked.dart';
 
 // Project imports:
@@ -15,11 +16,16 @@ class FaqViewModel extends BaseViewModel {
   final SettingsRepository _settingsManager = locator<SettingsRepository>();
 
   final LaunchUrlService _launchUrlService = locator<LaunchUrlService>();
+  final RemoteConfigService _remoteConfigService = locator<RemoteConfigService>();
 
   Locale? get locale => _settingsManager.locale;
 
   void launchWebsite(String link) {
     _launchUrlService.launchInBrowser(link);
+  }
+  
+  void launchPasswordReset() {
+    _launchUrlService.launchInBrowser(_remoteConfigService.signetsPasswordResetUrl);
   }
 
   Future<void> openMail(String addressEmail, BuildContext context) async {

--- a/lib/ui/more/faq/widgets/faq_view.dart
+++ b/lib/ui/more/faq/widgets/faq_view.dart
@@ -174,7 +174,7 @@ class _FaqViewState extends State<FaqView> {
                   builder: (BuildContext context) {
                     return NeedHelpNoticeDialog(
                         openMail: () => model.openMail(link, context),
-                        launchWebsite: () => model.launchWebsite(link));
+                        launchWebsite: () => model.launchPasswordReset());
                   });
             }
           },

--- a/test/ui/more/faq/view_model/faq_viewmodel_test.dart
+++ b/test/ui/more/faq/view_model/faq_viewmodel_test.dart
@@ -6,6 +6,7 @@ import 'package:mockito/mockito.dart';
 // Project imports:
 import 'package:notredame/data/repositories/settings_repository.dart';
 import 'package:notredame/data/services/launch_url_service.dart';
+import 'package:notredame/data/services/remote_config_service.dart';
 import 'package:notredame/ui/more/faq/view_model/faq_viewmodel.dart';
 import '../../../../data/mocks/services/launch_url_service_mock.dart';
 import '../../../../helpers.dart';
@@ -18,6 +19,7 @@ void main() {
     setUp(() async {
       launchUrlServiceMock = setupLaunchUrlServiceMock();
       setupSettingsManagerMock();
+      setupRemoteConfigServiceMock();
 
       viewModel = FaqViewModel();
     });
@@ -25,6 +27,7 @@ void main() {
     tearDown(() {
       unregister<SettingsRepository>();
       unregister<LaunchUrlService>();
+      unregister<RemoteConfigService>();
     });
 
     group('Webview - ', () {

--- a/test/ui/more/faq/widgets/faq_view_test.dart
+++ b/test/ui/more/faq/widgets/faq_view_test.dart
@@ -22,6 +22,7 @@ void main() {
     setUp(() async {
       setupLaunchUrlServiceMock();
       setupNetworkingServiceMock();
+      setupRemoteConfigServiceMock();
 
       settingsManagerMock = setupSettingsManagerMock();
       appIntl = await setupAppIntl();


### PR DESCRIPTION
### ⁉️ Related Issue
The url given to launchWebsite() was the email. This fixes that by providing the remote config link for resetting your password.

## 📖 Description
Remove password help links from intl files.
Add RemoteConfig password link.

I added `android/app/.cxx` to `.gitignore` as recommended here https://github.com/flutter/flutter/issues/163220#issuecomment-2659978902

### 🧪 How Has This Been Tested?
Manual tests

### ☑️ Checklist before requesting a review
- [ x ] I have performed a self-review of my code.
- [ N/A ] If it is a core feature, I have added thorough tests.
- [ N/A ] If needed, I added analytics.
- [ patch ] Make sure to add either one of the following labels: `version: Major`,`version: Minor` or `version: Patch`. 

### 🖼️ Screenshots (if useful):
<!--- If it's a visual change, please provide a screenshot -->
