### PR TITLE
Init grades at N/A instead of 0%

### DIFF
--- a/lib/data/services/signets-api/models/course_summary.dart
+++ b/lib/data/services/signets-api/models/course_summary.dart
@@ -15,7 +15,7 @@ class CourseSummary {
 
   /// Mark obtained by the student in percent.
   /// (ex: 24)
-  final double currentMarkInPercent;
+  final double? currentMarkInPercent;
 
   /// On how much the course is actually corrected (ex: 30)
   /// Sum of all the evaluations weight already published.
@@ -53,7 +53,7 @@ class CourseSummary {
           : null,
       currentMarkInPercent: node.getElement("noteACeJour")!.innerText.isNotEmpty
           ? double.parse(node.getElement("noteACeJour")!.innerText.replaceAll(",", "."))
-          : 0.0,
+          : null,
       markOutOf: node.getElement("tauxPublication")!.innerText.isNotEmpty
           ? double.parse(node.getElement("tauxPublication")!.innerText.replaceAll(",", "."))
           : 0.0,
@@ -74,7 +74,7 @@ class CourseSummary {
   /// Used to create [CourseSummary] instance from a JSON file
   factory CourseSummary.fromJson(Map<String, dynamic> json) => CourseSummary(
       currentMark: json["currentMark"] as double?,
-      currentMarkInPercent: json["currentMarkInPercent"] as double,
+      currentMarkInPercent: json["currentMarkInPercent"] as double?,
       markOutOf: json["markOutOf"] as double,
       passMark: json["passMark"] as double?,
       standardDeviation: json["standardDeviation"] as double?,

--- a/lib/ui/student/grades/grade_details/widgets/grade_details_view.dart
+++ b/lib/ui/student/grades/grade_details/widgets/grade_details_view.dart
@@ -194,7 +194,8 @@ class _GradesDetailsViewState extends State<GradesDetailsView> with TickerProvid
                           context,
                           model.course.summary?.median.toString(),
                           AppIntl.of(context)!.grades_grade_in_percentage(Utils.getGradeInPercentage(
-                              model.course.summary?.median, model.course.summary?.markOutOf) ?? 0.0),
+                                  model.course.summary?.median, model.course.summary?.markOutOf) ??
+                              0.0),
                         ),
                       ),
                     ),
@@ -267,10 +268,15 @@ class _GradesDetailsViewState extends State<GradesDetailsView> with TickerProvid
         FittedBox(
           fit: BoxFit.fitWidth,
           child: Text(
-              Utils.validateResultWithPercentage(context, currentGrade, maxGrade ?? 0.0, Utils.getGradeInPercentage(
-                      currentGrade,
-                      maxGrade,
-                    ) ?? 0.0),
+              Utils.validateResultWithPercentage(
+                  context,
+                  currentGrade,
+                  maxGrade ?? 0.0,
+                  Utils.getGradeInPercentage(
+                        currentGrade,
+                        maxGrade,
+                      ) ??
+                      0.0),
               style: Theme.of(context).textTheme.titleLarge!.copyWith(color: color)),
         ),
         Text(recipient, style: Theme.of(context).textTheme.bodyLarge!.copyWith(color: color)),

--- a/lib/ui/student/grades/grade_details/widgets/grade_details_view.dart
+++ b/lib/ui/student/grades/grade_details/widgets/grade_details_view.dart
@@ -194,7 +194,7 @@ class _GradesDetailsViewState extends State<GradesDetailsView> with TickerProvid
                           context,
                           model.course.summary?.median.toString(),
                           AppIntl.of(context)!.grades_grade_in_percentage(Utils.getGradeInPercentage(
-                              model.course.summary?.median, model.course.summary?.markOutOf)),
+                              model.course.summary?.median, model.course.summary?.markOutOf) ?? 0.0),
                         ),
                       ),
                     ),
@@ -267,14 +267,10 @@ class _GradesDetailsViewState extends State<GradesDetailsView> with TickerProvid
         FittedBox(
           fit: BoxFit.fitWidth,
           child: Text(
-              AppIntl.of(context)!.grades_grade_with_percentage(
-                currentGrade ?? 0.0,
-                maxGrade ?? 0.0,
-                Utils.getGradeInPercentage(
-                  currentGrade,
-                  maxGrade,
-                ),
-              ),
+              Utils.validateResultWithPercentage(context, currentGrade, maxGrade ?? 0.0, Utils.getGradeInPercentage(
+                      currentGrade,
+                      maxGrade,
+                    ) ?? 0.0),
               style: Theme.of(context).textTheme.titleLarge!.copyWith(color: color)),
         ),
         Text(recipient, style: Theme.of(context).textTheme.bodyLarge!.copyWith(color: color)),

--- a/lib/ui/student/grades/widgets/grade_button.dart
+++ b/lib/ui/student/grades/widgets/grade_button.dart
@@ -40,7 +40,9 @@ class GradeButton extends StatelessWidget {
     } else if (course.summary != null &&
         course.summary!.markOutOf > 0 &&
         !(course.inReviewPeriod && !(course.allReviewsCompleted ?? false))) {
-      return intl.grades_grade_in_percentage(course.summary!.currentMarkInPercent.round());
+      if (course.summary!.currentMarkInPercent != null) {
+        return intl.grades_grade_in_percentage(course.summary!.currentMarkInPercent!.round());
+      }
     }
 
     return intl.grades_not_available;

--- a/lib/ui/student/grades/widgets/grade_evaluation_tile.dart
+++ b/lib/ui/student/grades/widgets/grade_evaluation_tile.dart
@@ -140,13 +140,8 @@ class _GradeEvaluationTileState extends State<GradeEvaluationTile> with TickerPr
         children: [
           _buildSummary(
             AppIntl.of(context)!.grades_grade,
-            Utils.validateResultWithPercentage(
-                context,
-                evaluation.mark,
-                evaluation.correctedEvaluationOutOfFormatted,
-                Utils.getGradeInPercentage(evaluation.mark,
-                        evaluation.correctedEvaluationOutOfFormatted) ??
-                    0.0),
+            Utils.validateResultWithPercentage(context, evaluation.mark, evaluation.correctedEvaluationOutOfFormatted,
+                Utils.getGradeInPercentage(evaluation.mark, evaluation.correctedEvaluationOutOfFormatted) ?? 0.0),
           ),
           _buildSummary(
             AppIntl.of(context)!.grades_average,
@@ -154,29 +149,17 @@ class _GradeEvaluationTileState extends State<GradeEvaluationTile> with TickerPr
                 context,
                 evaluation.passMark,
                 evaluation.correctedEvaluationOutOfFormatted,
-                Utils.getGradeInPercentage(evaluation.passMark,
-                        evaluation.correctedEvaluationOutOfFormatted) ??
-                    0.0),
+                Utils.getGradeInPercentage(evaluation.passMark, evaluation.correctedEvaluationOutOfFormatted) ?? 0.0),
           ),
           _buildSummary(
             AppIntl.of(context)!.grades_median,
-            Utils.validateResultWithPercentage(
-                context,
-                evaluation.median,
-                evaluation.correctedEvaluationOutOfFormatted,
-                Utils.getGradeInPercentage(evaluation.median,
-                        evaluation.correctedEvaluationOutOfFormatted) ??
-                    0.0),
+            Utils.validateResultWithPercentage(context, evaluation.median, evaluation.correctedEvaluationOutOfFormatted,
+                Utils.getGradeInPercentage(evaluation.median, evaluation.correctedEvaluationOutOfFormatted) ?? 0.0),
           ),
           _buildSummary(
               AppIntl.of(context)!.grades_weighted,
-              Utils.validateResultWithPercentage(
-                  context,
-                  evaluation.weightedGrade,
-                  evaluation.weight,
-                  Utils.getGradeInPercentage(evaluation.mark,
-                          evaluation.correctedEvaluationOutOfFormatted) ??
-                      0.0)),
+              Utils.validateResultWithPercentage(context, evaluation.weightedGrade, evaluation.weight,
+                  Utils.getGradeInPercentage(evaluation.mark, evaluation.correctedEvaluationOutOfFormatted) ?? 0.0)),
           _buildSummary(AppIntl.of(context)!.grades_standard_deviation,
               validateResult(context, evaluation.standardDeviation.toString())),
           _buildSummary(AppIntl.of(context)!.grades_percentile_rank,

--- a/lib/ui/student/grades/widgets/grade_evaluation_tile.dart
+++ b/lib/ui/student/grades/widgets/grade_evaluation_tile.dart
@@ -140,32 +140,43 @@ class _GradeEvaluationTileState extends State<GradeEvaluationTile> with TickerPr
         children: [
           _buildSummary(
             AppIntl.of(context)!.grades_grade,
-            AppIntl.of(context)!.grades_grade_with_percentage(
-              evaluation.mark ?? 0.0,
-              evaluation.correctedEvaluationOutOf,
-              Utils.getGradeInPercentage(evaluation.mark, evaluation.correctedEvaluationOutOfFormatted),
-            ),
+            Utils.validateResultWithPercentage(
+                context,
+                evaluation.mark,
+                evaluation.correctedEvaluationOutOfFormatted,
+                Utils.getGradeInPercentage(evaluation.mark,
+                        evaluation.correctedEvaluationOutOfFormatted) ??
+                    0.0),
           ),
           _buildSummary(
             AppIntl.of(context)!.grades_average,
-            AppIntl.of(context)!.grades_grade_with_percentage(
-              evaluation.passMark ?? 0.0,
-              evaluation.correctedEvaluationOutOf,
-              Utils.getGradeInPercentage(evaluation.passMark, evaluation.correctedEvaluationOutOfFormatted),
-            ),
+            Utils.validateResultWithPercentage(
+                context,
+                evaluation.passMark,
+                evaluation.correctedEvaluationOutOfFormatted,
+                Utils.getGradeInPercentage(evaluation.passMark,
+                        evaluation.correctedEvaluationOutOfFormatted) ??
+                    0.0),
           ),
           _buildSummary(
             AppIntl.of(context)!.grades_median,
-            AppIntl.of(context)!.grades_grade_with_percentage(
-              evaluation.median ?? 0.0,
-              evaluation.correctedEvaluationOutOf,
-              Utils.getGradeInPercentage(evaluation.median, evaluation.correctedEvaluationOutOfFormatted),
-            ),
+            Utils.validateResultWithPercentage(
+                context,
+                evaluation.median,
+                evaluation.correctedEvaluationOutOfFormatted,
+                Utils.getGradeInPercentage(evaluation.median,
+                        evaluation.correctedEvaluationOutOfFormatted) ??
+                    0.0),
           ),
           _buildSummary(
               AppIntl.of(context)!.grades_weighted,
-              validateResultWithPercentage(context, evaluation.weightedGrade, evaluation.weight,
-                  Utils.getGradeInPercentage(evaluation.mark, evaluation.correctedEvaluationOutOfFormatted))),
+              Utils.validateResultWithPercentage(
+                  context,
+                  evaluation.weightedGrade,
+                  evaluation.weight,
+                  Utils.getGradeInPercentage(evaluation.mark,
+                          evaluation.correctedEvaluationOutOfFormatted) ??
+                      0.0)),
           _buildSummary(AppIntl.of(context)!.grades_standard_deviation,
               validateResult(context, evaluation.standardDeviation.toString())),
           _buildSummary(AppIntl.of(context)!.grades_percentile_rank,
@@ -205,14 +216,5 @@ class _GradeEvaluationTileState extends State<GradeEvaluationTile> with TickerPr
     }
 
     return AppIntl.of(context)!.grades_not_available;
-  }
-
-  String validateResultWithPercentage(BuildContext context, double? result, double maxGrade, double percentage) {
-    if (result == null) {
-      return AppIntl.of(context)!.grades_not_available;
-    }
-
-    final String formattedResult = result.toStringAsFixed(2);
-    return AppIntl.of(context)!.grades_grade_with_percentage(double.parse(formattedResult), maxGrade, percentage);
   }
 }

--- a/lib/utils/utils.dart
+++ b/lib/utils/utils.dart
@@ -30,7 +30,8 @@ mixin Utils {
     return DateTime(date.year, date.month);
   }
 
-  static String validateResultWithPercentage(BuildContext context, double? result, double? maxGrade, double percentage) {
+  static String validateResultWithPercentage(
+      BuildContext context, double? result, double? maxGrade, double percentage) {
     if (result == null || maxGrade == null) {
       return AppIntl.of(context)!.grades_not_available;
     }

--- a/lib/utils/utils.dart
+++ b/lib/utils/utils.dart
@@ -3,10 +3,15 @@ import 'package:flutter/material.dart';
 
 // Package imports:
 import 'package:calendar_view/calendar_view.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 mixin Utils {
-  static double getGradeInPercentage(double? grade, double? maxGrade) {
-    if (grade == null || maxGrade == null || grade == 0.0 || maxGrade == 0.0) {
+  static double? getGradeInPercentage(double? grade, double? maxGrade) {
+    if (grade == null || maxGrade == null) {
+      return null;
+    }
+
+    if (grade == 0.0 || maxGrade == 0.0) {
       return 0.0;
     }
 
@@ -23,5 +28,14 @@ mixin Utils {
 
   static DateTime getFirstDayOfMonth(DateTime date) {
     return DateTime(date.year, date.month);
+  }
+
+  static String validateResultWithPercentage(BuildContext context, double? result, double? maxGrade, double percentage) {
+    if (result == null || maxGrade == null) {
+      return AppIntl.of(context)!.grades_not_available;
+    }
+
+    final String formattedResult = result.toStringAsFixed(2);
+    return AppIntl.of(context)!.grades_grade_with_percentage(double.parse(formattedResult), maxGrade, percentage);
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ description: The 4th generation of ÉTSMobile, the main gateway between the Éco
 # pub.dev using `pub publish`. This is preferred for private packages.
 publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 
-version: 4.58.2
+version: 4.58.3
 
 environment:
   sdk: '>=3.6.0 <4.0.0'

--- a/test/ui/student/grades/grade_details/widgets/grades_details_view_test.dart
+++ b/test/ui/student/grades/grade_details/widgets/grades_details_view_test.dart
@@ -3,7 +3,9 @@ import 'package:flutter/material.dart';
 
 // Package imports:
 import 'package:flutter_test/flutter_test.dart';
+import 'package:intl/intl.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 // Project imports:
 import 'package:notredame/data/repositories/course_repository.dart';
@@ -18,6 +20,7 @@ import '../../../../../data/mocks/repositories/course_repository_mock.dart';
 import '../../../../../helpers.dart';
 
 void main() {
+  late AppIntl intl;
   TestWidgetsFlutterBinding.ensureInitialized();
 
   SharedPreferences.setMockInitialValues({});
@@ -50,8 +53,29 @@ void main() {
     ],
   );
 
+  final CourseSummary courseSummary2 = CourseSummary(
+    currentMark: null,
+    currentMarkInPercent: null,
+    markOutOf: 100,
+    passMark: 60,
+    standardDeviation: 2.3,
+    median: 4.5,
+    percentileRank: 99,
+    evaluations: []
+  );
+
   final completedCourseReview = CourseReview(
     acronym: 'GEN101',
+    group: '02',
+    teacherName: 'TEST',
+    startAt: DateTime.now().subtract(const Duration(days: 1)),
+    endAt: DateTime.now().add(const Duration(days: 1)),
+    type: 'Cours',
+    isCompleted: true,
+  );
+
+  final completedCourseReview2 = CourseReview(
+    acronym: 'GEN102',
     group: '02',
     teacherName: 'TEST',
     startAt: DateTime.now().subtract(const Duration(days: 1)),
@@ -70,7 +94,7 @@ void main() {
     isCompleted: false,
   );
 
-  final completedReviewList = <CourseReview>[completedCourseReview];
+  final completedReviewList = <CourseReview>[completedCourseReview, completedCourseReview2];
   final nonCompletedReviewList = <CourseReview>[nonCompletedCourseReview];
 
   final Course course = Course(
@@ -81,6 +105,16 @@ void main() {
       numberOfCredits: 3,
       title: 'Cours générique',
       summary: courseSummary,
+      reviews: completedReviewList);
+
+  final Course course2 = Course(
+      acronym: 'GEN102',
+      group: '02',
+      session: 'H2020',
+      programCode: '999',
+      numberOfCredits: 3,
+      title: 'Cours générique',
+      summary: courseSummary2,
       reviews: completedReviewList);
 
   final Course courseWithoutSummary = Course(
@@ -108,6 +142,7 @@ void main() {
       courseRepositoryMock = setupCourseRepositoryMock();
       setupSettingsRepositoryMock();
       setupNetworkingServiceMock();
+      intl = await setupAppIntl();
     });
 
     tearDown(() {
@@ -160,6 +195,29 @@ void main() {
           expect(find.text('Group 02'), findsOneWidget);
           expect(find.text('Professor: TEST'), findsOneWidget);
           expect(find.text('Credits: 3'), findsOneWidget);
+        });
+      });
+
+      testWidgets(
+          'when the page is at the top, it displays the course title, acronym, group, professor name and number of credits along with current grade and circular progress',
+          (WidgetTester tester) async {
+        setupFlutterToastMock(tester);
+        CourseRepositoryMock.stubGetCourseSummary(courseRepositoryMock, course2, toReturn: course2);
+        await tester.runAsync(() async {
+          await tester.pumpWidget(localizedWidget(child: GradesDetailsView(course: course2)));
+          await tester.pumpAndSettle();
+        }).then((value) {
+          expect(find.byType(SliverAppBar), findsOneWidget);
+
+          expect(find.text(course2.title), findsOneWidget);
+          expect(find.text(course2.acronym), findsOneWidget);
+          expect(find.text('Group 02'), findsOneWidget);
+          expect(find.text('Professor: TEST'), findsOneWidget);
+          expect(find.text('Credits: 3'), findsOneWidget);
+
+          final labelNa = find.text(intl.grades_not_available);
+          // One for circular progress and one for the "Your grade" label
+          expect(labelNa, findsAtLeastNWidgets(2));
         });
       });
 

--- a/test/ui/student/grades/grade_details/widgets/grades_details_view_test.dart
+++ b/test/ui/student/grades/grade_details/widgets/grades_details_view_test.dart
@@ -4,7 +4,6 @@ import 'package:flutter/material.dart';
 // Package imports:
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:intl/intl.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 // Project imports:

--- a/test/ui/student/grades/grade_details/widgets/grades_details_view_test.dart
+++ b/test/ui/student/grades/grade_details/widgets/grades_details_view_test.dart
@@ -2,10 +2,10 @@
 import 'package:flutter/material.dart';
 
 // Package imports:
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:intl/intl.dart';
 import 'package:shared_preferences/shared_preferences.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 // Project imports:
 import 'package:notredame/data/repositories/course_repository.dart';
@@ -54,15 +54,14 @@ void main() {
   );
 
   final CourseSummary courseSummary2 = CourseSummary(
-    currentMark: null,
-    currentMarkInPercent: null,
-    markOutOf: 100,
-    passMark: 60,
-    standardDeviation: 2.3,
-    median: 4.5,
-    percentileRank: 99,
-    evaluations: []
-  );
+      currentMark: null,
+      currentMarkInPercent: null,
+      markOutOf: 100,
+      passMark: 60,
+      standardDeviation: 2.3,
+      median: 4.5,
+      percentileRank: 99,
+      evaluations: []);
 
   final completedCourseReview = CourseReview(
     acronym: 'GEN101',

--- a/test/ui/student/grades/widgets/grade_button_test.dart
+++ b/test/ui/student/grades/widgets/grade_button_test.dart
@@ -26,6 +26,15 @@ void main() {
       numberOfCredits: 3,
       title: 'Cours générique');
 
+  final Course courseWithGrade2 = Course(
+      acronym: 'GEN102',
+      group: '02',
+      session: 'H2020',
+      programCode: '999',
+      grade: 'B+',
+      numberOfCredits: 3,
+      title: 'Cours générique');
+
   final Course courseWithSummary = Course(
       acronym: 'GEN101',
       group: '02',
@@ -38,6 +47,23 @@ void main() {
           currentMarkInPercent: 50,
           markOutOf: 10,
           passMark: 6,
+          standardDeviation: 2.3,
+          median: 4.5,
+          percentileRank: 99,
+          evaluations: []));
+
+  final Course courseWithSummary2 = Course(
+      acronym: 'GEN102',
+      group: '02',
+      session: 'H2020',
+      programCode: '999',
+      numberOfCredits: 3,
+      title: 'Cours générique',
+      summary: CourseSummary(
+          currentMark: null,
+          currentMarkInPercent: null,
+          markOutOf: 100,
+          passMark: 60,
           standardDeviation: 2.3,
           median: 4.5,
           percentileRank: 99,
@@ -77,10 +103,21 @@ void main() {
         await tester.pumpAndSettle();
 
         expect(find.text(courseWithGrade.acronym), findsOneWidget);
-        expect(find.text(intl.grades_grade_in_percentage(courseWithSummary.summary!.currentMarkInPercent.round())),
+        expect(find.text(intl.grades_grade_in_percentage(courseWithSummary.summary!.currentMarkInPercent!.round())),
             findsOneWidget,
             reason: 'There is no grade available and the course summary exists so the '
                 'current mark in percentage should be displayed');
+      });
+
+      testWidgets("Grade not available (currentMarkInPercent == null) and summary is loaded.",
+          (WidgetTester tester) async {
+        await tester.pumpWidget(localizedWidget(child: GradeButton(courseWithSummary2)));
+        await tester.pumpAndSettle();
+
+        expect(find.text(courseWithGrade2.acronym), findsOneWidget);
+        expect(find.text(intl.grades_not_available), findsOneWidget,
+            reason: 'The course summary exists but the current mark in percentage is null so '
+                'N/A should be displayed');
       });
 
       testWidgets("Grade and summary not available.", (WidgetTester tester) async {
@@ -89,7 +126,7 @@ void main() {
 
         expect(find.text(courseWithGrade.acronym), findsOneWidget);
         expect(find.text(intl.grades_not_available), findsOneWidget,
-            reason: 'There is no grade available and the course summary doesnt exists '
+            reason: 'There is no grade available and the course summary doesn\'t exist '
                 'so "N/A" should be displayed');
       });
     });

--- a/test/ui/student/grades/widgets/grade_evaluation_tile_test.dart
+++ b/test/ui/student/grades/widgets/grade_evaluation_tile_test.dart
@@ -104,7 +104,8 @@ void main() {
         final label3 = find.text(intl.grades_grade_with_percentage(
             evaluation.mark!,
             evaluation.correctedEvaluationOutOfFormatted,
-            Utils.getGradeInPercentage(double.parse(formattedMark), evaluation.correctedEvaluationOutOfFormatted) ?? 0.0));
+            Utils.getGradeInPercentage(double.parse(formattedMark), evaluation.correctedEvaluationOutOfFormatted) ??
+                0.0));
         expect(label3, findsOneWidget);
 
         final String formattedPassMark = evaluation.passMark!.toStringAsFixed(2);

--- a/test/ui/student/grades/widgets/grade_evaluation_tile_test.dart
+++ b/test/ui/student/grades/widgets/grade_evaluation_tile_test.dart
@@ -12,6 +12,7 @@ import 'package:notredame/data/services/signets-api/models/course_evaluation.dar
 import 'package:notredame/data/services/signets-api/models/course_summary.dart';
 import 'package:notredame/ui/student/grades/widgets/grade_circular_progress.dart';
 import 'package:notredame/ui/student/grades/widgets/grade_evaluation_tile.dart';
+import 'package:notredame/utils/utils.dart';
 import '../../../../helpers.dart';
 
 void main() {
@@ -76,6 +77,64 @@ void main() {
         expect(label2, findsOneWidget);
       });
 
+      testWidgets("display values when the information is not null", (WidgetTester tester) async {
+        final evaluation = courseSummary.evaluations.first;
+
+        final widget = localizedWidget(child: GradeEvaluationTile(evaluation, completed: true));
+
+        await tester.pumpWidget(widget);
+
+        await tester.pumpAndSettle();
+
+        final circularPercentIndicator = find.byType(GradeCircularProgress);
+        expect(circularPercentIndicator, findsOneWidget);
+
+        // Tap the button.
+        await tester.tap(find.byType(ExpansionTile));
+
+        await tester.pumpFrames(widget, const Duration(seconds: 5));
+
+        final label = find.text(evaluation.title);
+        expect(label, findsOneWidget);
+
+        final label2 = find.text("Weight: 10.0 %");
+        expect(label2, findsOneWidget);
+
+        final String formattedMark = evaluation.mark!.toStringAsFixed(2);
+        final label3 = find.text(intl.grades_grade_with_percentage(
+            evaluation.mark!,
+            evaluation.correctedEvaluationOutOfFormatted,
+            Utils.getGradeInPercentage(double.parse(formattedMark), evaluation.correctedEvaluationOutOfFormatted) ?? 0.0));
+        expect(label3, findsOneWidget);
+
+        final String formattedPassMark = evaluation.passMark!.toStringAsFixed(2);
+        final label4 = find.text(intl.grades_grade_with_percentage(
+            double.parse(formattedPassMark),
+            evaluation.correctedEvaluationOutOfFormatted,
+            Utils.getGradeInPercentage(evaluation.passMark!, evaluation.correctedEvaluationOutOfFormatted) ?? 0.0));
+        expect(label4, findsOneWidget);
+
+        final String formattedAverage = evaluation.passMark!.toStringAsFixed(2);
+        final label5 = find.text(intl.grades_grade_with_percentage(
+            double.parse(formattedAverage),
+            evaluation.correctedEvaluationOutOfFormatted,
+            Utils.getGradeInPercentage(evaluation.passMark!, evaluation.correctedEvaluationOutOfFormatted) ?? 0.0));
+        expect(label5, findsOneWidget);
+
+        final String formattedMedian = evaluation.median!.toStringAsFixed(2);
+        final label6 = find.text(intl.grades_grade_with_percentage(
+            double.parse(formattedMedian),
+            evaluation.correctedEvaluationOutOfFormatted,
+            Utils.getGradeInPercentage(evaluation.median!, evaluation.correctedEvaluationOutOfFormatted) ?? 0.0));
+        expect(label6, findsOneWidget);
+
+        final label7 = find.text(evaluation.standardDeviation.toString());
+        expect(label7, findsOneWidget);
+
+        final label8 = find.text(evaluation.percentileRank.toString());
+        expect(label8, findsOneWidget);
+      });
+
       testWidgets("display N/A when the information is null", (WidgetTester tester) async {
         final evaluation = courseSummary.evaluations.last;
 
@@ -100,11 +159,12 @@ void main() {
         expect(label2, findsOneWidget);
 
         final label3 = find.text(intl.grades_not_available);
-        //grades_weighted_grade, grades_standard_deviation, grades_percentile_rank
-        expect(label3, findsNWidgets(3));
-
-        final label4 = find.text("0.0/30 (0.0%)");
-        expect(label4, findsNWidgets(3));
+        /*
+          grade_grade (circular progress), grade_grade, grades_average,
+          grades_median, grades_weighted_grade,grades_standard_deviation,
+          grades_percentile_rank
+        */
+        expect(label3, findsNWidgets(7));
       });
     });
   });


### PR DESCRIPTION
### ⁉️ Related Issue
#885 

## 📖 Description
Grades are init at at `N/A` when they are `null` instead of `0%`. This is to avoid confusing the user in the rare cases where the teacher doesn't post all the students grades at the same time.

### 🧪 How Has This Been Tested?
Manual testing and unit tests

### ☑️ Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.
- [ ] If needed, I added analytics.
- [x] Make sure to add either one of the following labels: `version: Major`,`version: Minor` or `version: Patch`. 
