### PR TITLE
Check if the active course reviews are completed instead of all course reviews

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -81,7 +81,7 @@ PODS:
     - FirebaseSharedSwift (~> 11.0)
     - GoogleUtilities/Environment (~> 8.0)
     - "GoogleUtilities/NSData+zlib (~> 8.0)"
-  - FirebaseRemoteConfigInterop (11.11.0)
+  - FirebaseRemoteConfigInterop (11.12.0)
   - FirebaseSessions (11.10.0):
     - FirebaseCore (~> 11.10.0)
     - FirebaseCoreExtension (~> 11.10.0)
@@ -91,7 +91,7 @@ PODS:
     - GoogleUtilities/UserDefaults (~> 8.0)
     - nanopb (~> 3.30910.0)
     - PromisesSwift (~> 2.1)
-  - FirebaseSharedSwift (11.11.0)
+  - FirebaseSharedSwift (11.12.0)
   - Flutter (1.0.0)
   - flutter_inappwebview_ios (0.0.1):
     - Flutter
@@ -300,9 +300,9 @@ SPEC CHECKSUMS:
   FirebaseCrashlytics: 84b073c997235740e6a951b7ee49608932877e5c
   FirebaseInstallations: 9980995bdd06ec8081dfb6ab364162bdd64245c3
   FirebaseRemoteConfig: 10695bc0ce3b103e3706a5578c43f2a9f69d5aaa
-  FirebaseRemoteConfigInterop: 85bdce8babed7814816496bb6f082bc05b0a45e1
+  FirebaseRemoteConfigInterop: 82b81fd06ee550cbeff40004e2c106daedf73e38
   FirebaseSessions: 9b3b30947b97a15370e0902ee7a90f50ef60ead6
-  FirebaseSharedSwift: b1d32c3b29a911dc174bcf363f2f70bda9509d2f
+  FirebaseSharedSwift: d2475748a2d2a36242ed13baa34b2acda846c925
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
   flutter_inappwebview_ios: 6f63631e2c62a7c350263b13fa5427aedefe81d4
   flutter_secure_storage: d33dac7ae2ea08509be337e775f6b59f1ff45f12

--- a/lib/data/services/signets-api/models/course.dart
+++ b/lib/data/services/signets-api/models/course.dart
@@ -61,7 +61,8 @@ class Course {
     }
 
     final now = DateTime.now();
-    final activeReviews = reviews!.where((review) => review.startAt.isBefore(now) && review.endAt.isAfter(now)).toList();
+    final activeReviews =
+        reviews!.where((review) => review.startAt.isBefore(now) && review.endAt.isAfter(now)).toList();
 
     return activeReviews.isNotEmpty && activeReviews.every((review) => review.isCompleted);
   }

--- a/lib/data/services/signets-api/models/course.dart
+++ b/lib/data/services/signets-api/models/course.dart
@@ -59,7 +59,11 @@ class Course {
     if (reviews == null) {
       return true;
     }
-    return reviews!.every((review) => review.isCompleted);
+
+    final now = DateTime.now();
+    final activeReviews = reviews!.where((review) => review.startAt.isBefore(now) && review.endAt.isAfter(now)).toList();
+
+    return activeReviews.isNotEmpty && activeReviews.every((review) => review.isCompleted);
   }
 
   Course(

--- a/test/ui/student/grades/grade_details/widgets/grades_details_view_test.dart
+++ b/test/ui/student/grades/grade_details/widgets/grades_details_view_test.dart
@@ -70,8 +70,19 @@ void main() {
     isCompleted: false,
   );
 
+  final futureInactiveCourseReview = CourseReview(
+    acronym: 'GEN101',
+    group: '02',
+    teacherName: 'TEST',
+    startAt: DateTime.now().add(const Duration(days: 30)),
+    endAt: DateTime.now().add(const Duration(days: 60)),
+    type: 'Cours',
+    isCompleted: false,
+  );
+
   final completedReviewList = <CourseReview>[completedCourseReview];
-  final nonCompletedReviewList = <CourseReview>[nonCompletedCourseReview];
+  final nonCompletedReviewList = <CourseReview>[nonCompletedCourseReview, futureInactiveCourseReview];
+  final semiCompletedReviewList = <CourseReview>[completedCourseReview, futureInactiveCourseReview];
 
   final Course course = Course(
       acronym: 'GEN101',
@@ -91,6 +102,16 @@ void main() {
     numberOfCredits: 3,
     title: 'Cours générique',
   );
+
+  final Course courseWithEvaluationSemiCompleted = Course(
+      acronym: 'GEN101',
+      group: '02',
+      session: 'H2020',
+      programCode: '999',
+      numberOfCredits: 3,
+      title: 'Cours générique',
+      summary: courseSummary,
+      reviews: semiCompletedReviewList);
 
   final Course courseWithEvaluationNotCompleted = Course(
       acronym: 'GEN101',
@@ -204,6 +225,33 @@ void main() {
 
         expect(find.byKey(const Key("EvaluationNotCompleted")), findsOneWidget);
       });
+
+      testWidgets(
+          'display regular course content (evaluations, circular progress, etc) when in the evaluation period and the evaluation is completed with a future (inactive) review not completed',
+          (WidgetTester tester) async {
+        setupFlutterToastMock(tester);
+        CourseRepositoryMock.stubGetCourseSummary(courseRepositoryMock, courseWithEvaluationSemiCompleted, toReturn: courseWithEvaluationSemiCompleted);
+        await tester.runAsync(() async {
+          await tester.pumpWidget(localizedWidget(child: GradesDetailsView(course: courseWithEvaluationSemiCompleted)));
+          await tester.pumpAndSettle(const Duration(seconds: 2));
+        }).then(
+          (value) {
+            expect(find.byType(RefreshIndicator), findsOneWidget);
+
+            // Find all the grade circular progress
+            expect(find.byKey(const Key("GradeCircularProgress_summary")), findsOneWidget);
+            for (final eval in courseSummary.evaluations) {
+              expect(find.byKey(Key("GradeCircularProgress_${eval.title}")), findsOneWidget);
+            }
+
+            expect(find.byType(Card), findsNWidgets(5));
+
+            for (final eval in courseSummary.evaluations) {
+              expect(find.byKey(Key("GradeEvaluationTile_${eval.title}")), findsOneWidget);
+            }
+          },
+        );
+      });      
     });
   });
 }

--- a/test/ui/student/grades/grade_details/widgets/grades_details_view_test.dart
+++ b/test/ui/student/grades/grade_details/widgets/grades_details_view_test.dart
@@ -230,7 +230,8 @@ void main() {
           'display regular course content (evaluations, circular progress, etc) when in the evaluation period and the evaluation is completed with a future (inactive) review not completed',
           (WidgetTester tester) async {
         setupFlutterToastMock(tester);
-        CourseRepositoryMock.stubGetCourseSummary(courseRepositoryMock, courseWithEvaluationSemiCompleted, toReturn: courseWithEvaluationSemiCompleted);
+        CourseRepositoryMock.stubGetCourseSummary(courseRepositoryMock, courseWithEvaluationSemiCompleted,
+            toReturn: courseWithEvaluationSemiCompleted);
         await tester.runAsync(() async {
           await tester.pumpWidget(localizedWidget(child: GradesDetailsView(course: courseWithEvaluationSemiCompleted)));
           await tester.pumpAndSettle(const Duration(seconds: 2));
@@ -251,7 +252,7 @@ void main() {
             }
           },
         );
-      });      
+      });
     });
   });
 }


### PR DESCRIPTION
### ⁉️ Related Issue
#1161 

## 📖 Description
The `allReviewsCompleted` flag in `course.dart` now checks if all the **active** course reviews have been completed.
An *active* course review represents a course review which the `startAt` date is before the current date and the `endAt` date is after the current date.

### 🧪 How Has This Been Tested?
Manual testing and existing/new unit tests

### ☑️ Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.
- [ ] If needed, I added analytics.
- [x] Make sure to add either one of the following labels: `version: Major`,`version: Minor` or `version: Patch`. 
