### PR TITLE
Internship programs shouldn't be the default

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -138,31 +138,31 @@ PODS:
   - GoogleMaps/Base (8.4.0)
   - GoogleMaps/Maps (8.4.0):
     - GoogleMaps/Base
-  - GoogleUtilities/AppDelegateSwizzler (8.0.2):
+  - GoogleUtilities/AppDelegateSwizzler (8.1.0):
     - GoogleUtilities/Environment
     - GoogleUtilities/Logger
     - GoogleUtilities/Network
     - GoogleUtilities/Privacy
-  - GoogleUtilities/Environment (8.0.2):
+  - GoogleUtilities/Environment (8.1.0):
     - GoogleUtilities/Privacy
-  - GoogleUtilities/Logger (8.0.2):
+  - GoogleUtilities/Logger (8.1.0):
     - GoogleUtilities/Environment
     - GoogleUtilities/Privacy
-  - GoogleUtilities/MethodSwizzler (8.0.2):
+  - GoogleUtilities/MethodSwizzler (8.1.0):
     - GoogleUtilities/Logger
     - GoogleUtilities/Privacy
-  - GoogleUtilities/Network (8.0.2):
+  - GoogleUtilities/Network (8.1.0):
     - GoogleUtilities/Logger
     - "GoogleUtilities/NSData+zlib"
     - GoogleUtilities/Privacy
     - GoogleUtilities/Reachability
-  - "GoogleUtilities/NSData+zlib (8.0.2)":
+  - "GoogleUtilities/NSData+zlib (8.1.0)":
     - GoogleUtilities/Privacy
-  - GoogleUtilities/Privacy (8.0.2)
-  - GoogleUtilities/Reachability (8.0.2):
+  - GoogleUtilities/Privacy (8.1.0)
+  - GoogleUtilities/Reachability (8.1.0):
     - GoogleUtilities/Logger
     - GoogleUtilities/Privacy
-  - GoogleUtilities/UserDefaults (8.0.2):
+  - GoogleUtilities/UserDefaults (8.1.0):
     - GoogleUtilities/Logger
     - GoogleUtilities/Privacy
   - in_app_review (2.0.0):
@@ -312,7 +312,7 @@ SPEC CHECKSUMS:
   GoogleAppMeasurement: 36684bfb3ee034e2b42b4321eb19da3a1b81e65d
   GoogleDataTransport: aae35b7ea0c09004c3797d53c8c41f66f219d6a7
   GoogleMaps: 8939898920281c649150e0af74aa291c60f2e77d
-  GoogleUtilities: 26a3abef001b6533cf678d3eb38fd3f614b7872d
+  GoogleUtilities: 00c88b9a86066ef77f0da2fab05f65d7768ed8e1
   in_app_review: a31b5257259646ea78e0e35fc914979b0031d011
   MSAL: 088bc688c1ce1a62f0d9c13905ddb31f8f1ac700
   msal_auth: 1a1feed23c03c9c2f627d9d1669b4bc8f1650853

--- a/lib/ui/student/profile/view_model/profile_viewmodel.dart
+++ b/lib/ui/student/profile/view_model/profile_viewmodel.dart
@@ -39,12 +39,7 @@ class ProfileViewModel extends FutureViewModel<List<Program>> {
     int percentage = 0;
 
     if (programList.isNotEmpty) {
-      Program currentProgram = programList.first;
-      for (final program in programList) {
-        if (int.parse(program.registeredCredits) > int.parse(currentProgram.registeredCredits)) {
-          currentProgram = program;
-        }
-      }
+      Program currentProgram = getCurrentProgram();
       final int numberOfCreditsCompleted = int.parse(currentProgram.accumulatedCredits);
       final String code = currentProgram.code;
       bool foundMatch = false;
@@ -64,6 +59,13 @@ class ProfileViewModel extends FutureViewModel<List<Program>> {
     }
 
     return percentage;
+  }
+
+  Program getCurrentProgram() {
+    RegExp regExp = RegExp(r"^Microprogramme de \d+\w* cycle en enseignement coopératif");
+    List<Program> nonInternshipPrograms =
+        programList.where((item) => !regExp.hasMatch(item.name) && item.status.toLowerCase() == "actif").toList();
+    return nonInternshipPrograms.last;
   }
 
   @override

--- a/lib/ui/student/profile/widgets/profile_view.dart
+++ b/lib/ui/student/profile/widgets/profile_view.dart
@@ -99,7 +99,7 @@ Widget buildPage(BuildContext context, ProfileViewModel model) => Column(
           indent: 10,
           endIndent: 10,
         ),
-        getCurrentProgramTile(model.programList, context),
+        getCurrentProgramTile(model.getCurrentProgram(), context),
         const Divider(
           thickness: 2,
           indent: 10,
@@ -118,7 +118,7 @@ Widget buildPage(BuildContext context, ProfileViewModel model) => Column(
         ),
         Column(
           children: [
-            for (var i = 0; i < model.programList.length - 1; i++) StudentProgram(model.programList[i]),
+            for (var i = 0; i < getProgramListWithoutCurrent(model).length; i++) StudentProgram(getProgramListWithoutCurrent(model)[i]),
           ],
         ),
         const SizedBox(height: 10.0),
@@ -128,7 +128,7 @@ Widget buildPage(BuildContext context, ProfileViewModel model) => Column(
 Card getMainInfoCard(ProfileViewModel model) {
   var programName = "";
   if (model.programList.isNotEmpty) {
-    programName = model.programList.last.name;
+    programName = model.getCurrentProgram().name;
   }
 
   return Card(
@@ -264,57 +264,55 @@ Card getMyBalanceCard(ProfileViewModel model, BuildContext context) {
   );
 }
 
-Column getCurrentProgramTile(List<Program> programList, BuildContext context) {
-  if (programList.isNotEmpty) {
-    final program = programList.last;
+Column getCurrentProgramTile(Program program, BuildContext context) {
+  final List<String> dataTitles = [
+    AppIntl.of(context)!.profile_code_program,
+    AppIntl.of(context)!.profile_average_program,
+    AppIntl.of(context)!.profile_number_accumulated_credits_program,
+    AppIntl.of(context)!.profile_number_registered_credits_program,
+    AppIntl.of(context)!.profile_number_completed_courses_program,
+    AppIntl.of(context)!.profile_number_failed_courses_program,
+    AppIntl.of(context)!.profile_number_equivalent_courses_program,
+    AppIntl.of(context)!.profile_status_program
+  ];
 
-    final List<String> dataTitles = [
-      AppIntl.of(context)!.profile_code_program,
-      AppIntl.of(context)!.profile_average_program,
-      AppIntl.of(context)!.profile_number_accumulated_credits_program,
-      AppIntl.of(context)!.profile_number_registered_credits_program,
-      AppIntl.of(context)!.profile_number_completed_courses_program,
-      AppIntl.of(context)!.profile_number_failed_courses_program,
-      AppIntl.of(context)!.profile_number_equivalent_courses_program,
-      AppIntl.of(context)!.profile_status_program
-    ];
+  final List<String> dataFetched = [
+    program.code,
+    program.average,
+    program.accumulatedCredits,
+    program.registeredCredits,
+    program.completedCourses,
+    program.failedCourses,
+    program.equivalentCourses,
+    program.status
+  ];
 
-    final List<String> dataFetched = [
-      program.code,
-      program.average,
-      program.accumulatedCredits,
-      program.registeredCredits,
-      program.completedCourses,
-      program.failedCourses,
-      program.equivalentCourses,
-      program.status
-    ];
-
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.stretch,
-      children: [
-        Padding(
-          padding: const EdgeInsets.fromLTRB(16.0, 8.0, 16.0, 8.0),
-          child: Text(
-            program.name,
-            style: const TextStyle(fontSize: 18, fontWeight: FontWeight.bold, color: AppPalette.etsLightRed),
-          ),
+  return Column(
+    crossAxisAlignment: CrossAxisAlignment.stretch,
+    children: [
+      Padding(
+        padding: const EdgeInsets.fromLTRB(16.0, 8.0, 16.0, 8.0),
+        child: Text(
+          program.name,
+          style: const TextStyle(fontSize: 18, fontWeight: FontWeight.bold, color: AppPalette.etsLightRed),
         ),
-        ...List<Widget>.generate(dataTitles.length, (index) {
-          return Padding(
-            padding: const EdgeInsets.fromLTRB(16.0, 0.0, 16.0, 8.0),
-            child: Row(
-              mainAxisAlignment: MainAxisAlignment.spaceBetween,
-              children: <Widget>[
-                Text(dataTitles[index]),
-                Text(dataFetched[index]),
-              ],
-            ),
-          );
-        }),
-      ],
-    );
-  } else {
-    return const Column();
-  }
+      ),
+      ...List<Widget>.generate(dataTitles.length, (index) {
+        return Padding(
+          padding: const EdgeInsets.fromLTRB(16.0, 0.0, 16.0, 8.0),
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: <Widget>[
+              Text(dataTitles[index]),
+              Text(dataFetched[index]),
+            ],
+          ),
+        );
+      }),
+    ],
+  );
+}
+
+List<Program> getProgramListWithoutCurrent(ProfileViewModel model){
+  return model.programList.where((item) => item.hashCode != model.getCurrentProgram().hashCode).toList();
 }

--- a/lib/ui/student/profile/widgets/profile_view.dart
+++ b/lib/ui/student/profile/widgets/profile_view.dart
@@ -118,7 +118,8 @@ Widget buildPage(BuildContext context, ProfileViewModel model) => Column(
         ),
         Column(
           children: [
-            for (var i = 0; i < getProgramListWithoutCurrent(model).length; i++) StudentProgram(getProgramListWithoutCurrent(model)[i]),
+            for (var i = 0; i < getProgramListWithoutCurrent(model).length; i++)
+              StudentProgram(getProgramListWithoutCurrent(model)[i]),
           ],
         ),
         const SizedBox(height: 10.0),
@@ -313,6 +314,6 @@ Column getCurrentProgramTile(Program program, BuildContext context) {
   );
 }
 
-List<Program> getProgramListWithoutCurrent(ProfileViewModel model){
+List<Program> getProgramListWithoutCurrent(ProfileViewModel model) {
   return model.programList.where((item) => item.hashCode != model.getCurrentProgram().hashCode).toList();
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ description: The 4th generation of ÉTSMobile, the main gateway between the Éco
 # pub.dev using `pub publish`. This is preferred for private packages.
 publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 
-version: 4.58.3
+version: 4.58.4
 
 environment:
   sdk: '>=3.6.0 <4.0.0'

--- a/test/ui/student/profile/view_model/profile_viewmodel_test.dart
+++ b/test/ui/student/profile/view_model/profile_viewmodel_test.dart
@@ -216,5 +216,164 @@ void main() {
         verifyNoMoreInteractions(userRepositoryMock);
       });
     });
+
+    group('Programs with "Microprogramme [...] enseignement cooperatif" should not be the default program', () {
+      test('Bac program with no internships (microprogramme)', () async {
+        final List<Program> testPrograms = [
+          Program(
+            name: 'Baccalauréat en génie logiciel ',
+            code: '7084',
+            average: '3.00',
+            accumulatedCredits: '20',
+            registeredCredits: '0',
+            completedCourses: '10',
+            failedCourses: '1',
+            equivalentCourses: '0',
+            status: 'actif',
+          ),
+        ];
+
+        UserRepositoryMock.stubPrograms(userRepositoryMock, toReturn: testPrograms);
+
+        expect(testPrograms.first, viewModel.getCurrentProgram());
+      });
+
+      test('Bac program with 1 active internship (microprogramme)', () async {
+        final List<Program> testPrograms = [
+          Program(
+            name: 'Baccalauréat en génie logiciel ',
+            code: '7084',
+            average: '3.00',
+            accumulatedCredits: '20',
+            registeredCredits: '0',
+            completedCourses: '10',
+            failedCourses: '1',
+            equivalentCourses: '0',
+            status: 'actif',
+          ),
+          Program(
+            name: 'Microprogramme de 1er cycle en enseignement coopératif I',
+            code: '0725',
+            average: '',
+            accumulatedCredits: '0',
+            registeredCredits: '9',
+            completedCourses: '0',
+            failedCourses: '0',
+            equivalentCourses: '0',
+            status: 'actif',
+          ),
+        ];
+
+        UserRepositoryMock.stubPrograms(userRepositoryMock, toReturn: testPrograms);
+
+        expect(testPrograms.first, viewModel.getCurrentProgram());
+      });
+
+      test('Bac program with 1 active internship (microprogramme) and 1 completed', () async {
+        final List<Program> testPrograms = [
+          Program(
+            name: 'Baccalauréat en génie logiciel ',
+            code: '7084',
+            average: '3.00',
+            accumulatedCredits: '20',
+            registeredCredits: '0',
+            completedCourses: '10',
+            failedCourses: '1',
+            equivalentCourses: '0',
+            status: 'actif',
+          ),
+          Program(
+            name: 'Microprogramme de 1er cycle en enseignement coopératif I',
+            code: '0725',
+            average: '',
+            accumulatedCredits: '9',
+            registeredCredits: '0',
+            completedCourses: '1',
+            failedCourses: '0',
+            equivalentCourses: '0',
+            status: 'Dossier fermé',
+          ),
+          Program(
+            name: 'Microprogramme de 1er cycle en enseignement coopératif II',
+            code: '0726',
+            average: '',
+            accumulatedCredits: '0',
+            registeredCredits: '9',
+            completedCourses: '0',
+            failedCourses: '0',
+            equivalentCourses: '0',
+            status: 'actif',
+          ),
+        ];
+
+        UserRepositoryMock.stubPrograms(userRepositoryMock, toReturn: testPrograms);
+
+        expect(testPrograms.first, viewModel.getCurrentProgram());
+      });
+
+      test('Maitrise program with 3 completed internships', () async {
+        final List<Program> testPrograms = [
+          Program(
+            name: 'Baccalauréat en génie logiciel ',
+            code: '7084',
+            average: '3.00',
+            accumulatedCredits: '116',
+            registeredCredits: '0',
+            completedCourses: '40',
+            failedCourses: '0',
+            equivalentCourses: '0',
+            status: 'Diplome',
+          ),
+          Program(
+            name: 'Microprogramme de 1er cycle en enseignement coopératif I',
+            code: '0725',
+            average: '',
+            accumulatedCredits: '9',
+            registeredCredits: '0',
+            completedCourses: '1',
+            failedCourses: '0',
+            equivalentCourses: '0',
+            status: 'Dossier fermé',
+          ),
+          Program(
+            name: 'Microprogramme de 1er cycle en enseignement coopératif II',
+            code: '0726',
+            average: '',
+            accumulatedCredits: '9',
+            registeredCredits: '0',
+            completedCourses: '1',
+            failedCourses: '0',
+            equivalentCourses: '0',
+            status: 'Dossier fermé',
+          ),
+          Program(
+            name: 'Microprogramme de 1er cycle en enseignement coopératif III',
+            code: '0727',
+            average: '',
+            accumulatedCredits: '9',
+            registeredCredits: '0',
+            completedCourses: '1',
+            failedCourses: '0',
+            equivalentCourses: '0',
+            status: 'Dossier fermé',
+          ),
+          Program(
+            name: 'Maîtrise en génie logiciel',
+            code: '1822',
+            average: '3.00',
+            accumulatedCredits: '4',
+            registeredCredits: '12',
+            completedCourses: '1',
+            failedCourses: '0',
+            equivalentCourses: '0',
+            status: 'actif',
+          ),
+        ];
+
+        UserRepositoryMock.stubPrograms(userRepositoryMock, toReturn: testPrograms);
+
+        expect(testPrograms.last, viewModel.getCurrentProgram());
+      });
+    });
   });
 }

--- a/test/ui/student/profile/widgets/profile_view_test.dart
+++ b/test/ui/student/profile/widgets/profile_view_test.dart
@@ -10,6 +10,7 @@ import 'package:notredame/data/services/networking_service.dart';
 import 'package:notredame/data/services/signets-api/models/profile_student.dart';
 import 'package:notredame/data/services/signets-api/models/program.dart';
 import 'package:notredame/ui/student/profile/widgets/profile_view.dart';
+import 'package:notredame/ui/student/widgets/student_program.dart';
 import '../../../../data/mocks/repositories/user_repository_mock.dart';
 import '../../../../data/mocks/services/analytics_service_mock.dart';
 import '../../../../helpers.dart';
@@ -21,19 +22,41 @@ void main() {
   final profileStudent = ProfileStudent(
       firstName: "John", lastName: "Doe", permanentCode: "ABC123", balance: "123456789", universalCode: 'AA000000');
 
-  // Make a test program object
-  final program = Program(
-      name: "Program name",
-      code: "1234",
-      average: "4.20",
-      accumulatedCredits: "123",
-      registeredCredits: "123",
-      completedCourses: "123",
-      failedCourses: "123",
-      equivalentCourses: "123",
-      status: "Actif");
-
-  final programList = [program];
+  final programList = [
+    Program(
+      name: 'Baccalauréat en génie logiciel ',
+      code: '7084',
+      average: '3.00',
+      accumulatedCredits: '116',
+      registeredCredits: '0',
+      completedCourses: '40',
+      failedCourses: '0',
+      equivalentCourses: '0',
+      status: 'actif',
+    ),
+    Program(
+      name: 'Microprogramme de 1er cycle en enseignement coopératif I',
+      code: '0725',
+      average: '',
+      accumulatedCredits: '9',
+      registeredCredits: '0',
+      completedCourses: '1',
+      failedCourses: '0',
+      equivalentCourses: '0',
+      status: 'Dossier fermé',
+    ),
+    Program(
+      name: 'Microprogramme de 1er cycle en enseignement coopératif II',
+      code: '0726',
+      average: '',
+      accumulatedCredits: '0',
+      registeredCredits: '9',
+      completedCourses: '0',
+      failedCourses: '0',
+      equivalentCourses: '0',
+      status: 'actif',
+    ),
+  ];
 
   group('Profile view - ', () {
     setUp(() async {
@@ -61,7 +84,7 @@ void main() {
 
       expect(find.text("${profileStudent.firstName} ${profileStudent.lastName}"), findsOneWidget);
 
-      expect(find.text(program.name), findsNWidgets(2));
+      expect(find.text(programList[0].name), findsNWidgets(2));
     });
 
     testWidgets('contains personal info', (WidgetTester tester) async {
@@ -104,6 +127,17 @@ void main() {
       expect(find.text(intl.profile_program_completion), findsOneWidget);
 
       expect(find.byType(CircularProgressIndicator), findsOneWidget);
+    });
+
+    testWidgets('contains "other" programs section', (WidgetTester tester) async {
+      await tester.pumpWidget(localizedWidget(child: ProfileView()));
+      await tester.pumpAndSettle();
+
+      expect(find.text(intl.profile_other_programs), findsOneWidget);
+
+      expect(find.byType(StudentProgram), findsNWidgets(2));
+      expect(find.text(programList[1].name), findsOneWidget);
+      expect(find.text(programList[2].name), findsOneWidget);
     });
   });
 }


### PR DESCRIPTION
### ⁉️ Related Issue
#1126 

## 📖 Description
Added a function to determine the current program. 

```
Program getCurrentProgram() {
  RegExp regExp = RegExp(r"^Microprogramme de \d+\w* cycle en enseignement coopératif");
  List<Program> nonInternshipPrograms =
      programList.where((item) => !regExp.hasMatch(item.name) && item.status.toLowerCase() == "actif").toList();
  return nonInternshipPrograms.last;
}
```
We look for programs that don't match the regex pattern but that are also `status == "actif"`.
I can't confirm if this covers all the cases for *all* internships in *all* programs.

I would much rather filter out by `.code`.
Ex: `0725 -> Stage I`, `0726 -> Stage II`, etc. However, I also can't confirm if we have all the codes for all internship programs. 

### 🧪 How Has This Been Tested?
Manual testing and unit tests

### ☑️ Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.
- [ ] If needed, I added analytics.
- [x] Make sure to add either one of the following labels: `version: Major`,`version: Minor` or `version: Patch`. 
