### PR TITLE
Handle invalid token after password reset

### DIFF
--- a/lib/data/services/signets-api/request_builder_service.dart
+++ b/lib/data/services/signets-api/request_builder_service.dart
@@ -32,7 +32,6 @@ mixin RequestBuilderService {
     String resultTag, {
     Map<String, String>? queryParameters,
   }) async {
-    // Send the envelope
     final uri = Uri.https(Urls.signetsAPI, endpoint, queryParameters);
     final response = await client.get(uri, headers: _buildHeaders(token));
 
@@ -40,10 +39,23 @@ mixin RequestBuilderService {
       RequestBuilderService.retries++;
       if (retries > maxRetry) {
         retries = 0;
-        throw ApiException(prefix: tagError, message: "Token invalide. Veuillez vous déconnecter et vous reconnecter.");
+        throw ApiException(
+          prefix: tagError,
+          message: "Token invalide. Veuillez vous déconnecter et vous reconnecter."
+        );
       }
+
       final authService = locator<AuthService>();
-      await authService.acquireTokenSilent();
+      final tokenResult = await authService.acquireTokenSilent();
+      
+      if (tokenResult.$1 == null) {
+        retries = 0;
+        throw ApiException(
+          prefix: tagError,
+          message: "Session expirée. Veuillez vous reconnecter."
+        );
+      }
+
       return await sendRequest(
         client,
         endpoint,

--- a/test/data/services/signets_api/signets_api_client_test.dart
+++ b/test/data/services/signets_api/signets_api_client_test.dart
@@ -237,7 +237,7 @@ void main() {
           );
         } catch (e) {
           expect(e, isA<ApiException>());
-          verify(authServiceMock.acquireTokenSilent()).called(3);
+          verify(authServiceMock.acquireTokenSilent()).called(1);
         }
       });
     });


### PR DESCRIPTION
### ⁉️ Related Issue
N/A

## 📖 Description
This PR fixes an issue where the app would enter an infinite loop on launch after a user resets their password. The root cause was an invalid authentication token, which triggered repeated failures:

![Error](https://github.com/user-attachments/assets/cc09ef84-ec89-4cdf-a205-d5111faf2d7d)

### 🧪 How Has This Been Tested?
Manual tests:
- Reset password
- Wait for token to expire / become invalid (approx. 1 hour)
- Launch the app
- Confirm that the user is prompted to re-authenticate

### ☑️ Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] If needed, I added analytics.
- [x] Make sure to add either one of the following labels: `version: Major`,`version: Minor` or `version: Patch`. 

### 🖼️ Screenshots (if useful):
N/A