### PR TITLE
Fix pull-to-refresh on grades view

### DIFF
--- a/lib/ui/student/grades/widgets/grades_view.dart
+++ b/lib/ui/student/grades/widgets/grades_view.dart
@@ -35,19 +35,23 @@ class _GradesViewState extends State<GradesView> {
           onRefresh: () => model.refresh(),
           child: Stack(
             children: [
-              // This widget is here to make this widget a Scrollable. Needed
-              // by the RefreshIndicator
-              ListView(),
               if (model.coursesBySession.isEmpty)
-                Center(
-                  child: Text(
-                    AppIntl.of(context)!.grades_msg_no_grades,
-                    textAlign: TextAlign.center,
-                    style: Theme.of(context).textTheme.titleLarge,
+                SingleChildScrollView(
+                  physics: const AlwaysScrollableScrollPhysics(),
+                  child: SizedBox(
+                    height: MediaQuery.of(context).size.height,
+                    child: Center(
+                      child: Text(
+                        AppIntl.of(context)!.grades_msg_no_grades,
+                        textAlign: TextAlign.center,
+                        style: Theme.of(context).textTheme.titleLarge,
+                      ),
+                    ),
                   ),
                 )
               else
                 ListView.builder(
+                  physics: const AlwaysScrollableScrollPhysics(),
                   padding: const EdgeInsets.only(top: 8.0),
                   itemCount: model.coursesBySession.length,
                   itemBuilder: (BuildContext context, int index) => _buildSessionCourses(

--- a/lib/ui/student/grades/widgets/grades_view.dart
+++ b/lib/ui/student/grades/widgets/grades_view.dart
@@ -36,18 +36,19 @@ class _GradesViewState extends State<GradesView> {
           child: Stack(
             children: [
               if (model.coursesBySession.isEmpty)
-                SingleChildScrollView(
+                CustomScrollView(
                   physics: const AlwaysScrollableScrollPhysics(),
-                  child: SizedBox(
-                    height: MediaQuery.of(context).size.height,
-                    child: Center(
-                      child: Text(
-                        AppIntl.of(context)!.grades_msg_no_grades,
-                        textAlign: TextAlign.center,
-                        style: Theme.of(context).textTheme.titleLarge,
+                  slivers: [
+                    SliverFillRemaining(
+                      child: Center(
+                        child: Text(
+                          AppIntl.of(context)!.grades_msg_no_grades,
+                          textAlign: TextAlign.center,
+                          style: Theme.of(context).textTheme.titleLarge,
+                        ),
                       ),
                     ),
-                  ),
+                  ],
                 )
               else
                 ListView.builder(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ description: The 4th generation of ÉTSMobile, the main gateway between the Éco
 # pub.dev using `pub publish`. This is preferred for private packages.
 publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 
-version: 4.64.1
+version: 4.64.2
 
 environment:
   sdk: '>=3.9.0 <4.0.0'


### PR DESCRIPTION
### ⁉️ Related Issue
closes: #1112 

## 📖 Description
Fixes an issue where pull-to-refresh triggered before reaching the top of the grades view page when scrolling up, it looks like this was caused by a stacked empty `ListView` used to make the view scrollable.

 - Replaced empty `ListView` hack with `CustomScrollView` + `SliverFillRemaining` for the empty state.
 - Added `AlwaysScrollableScrollPhysics` to the grades `ListView.builder` so refresh works even when content doesn't overflow.

### 🧪 How Has This Been Tested?
Manually tested

### ☑️ Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.
- [ ] If needed, I added analytics.
- [x] Make sure to add either one of the following labels: `version: Major`,`version: Minor` or `version: Patch`. 

### 🖼️ Screenshots (if useful):
### Before:
[before.webm](https://github.com/user-attachments/assets/d8cba197-b4a5-402e-9d6c-47bd2e37fcbc)

### After:
[after.webm](https://github.com/user-attachments/assets/cab45f0f-4846-4b60-b67f-9beeea98e0aa)

<br />

<img width="300" height="600" alt="Screenshot_1773009684" src="https://github.com/user-attachments/assets/3bc71afd-eb52-48a2-aea2-cf84ea45dea1" />